### PR TITLE
Fixed next/prev frame

### DIFF
--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -72,7 +72,7 @@ void video_player::run()  {
     video_paused = false;
     int delay = (1000/frame_rate);
     capture.set(CV_CAP_PROP_POS_FRAMES, current_frame);
-    while(!video_stopped && capture.read(frame)){
+    while(!video_stopped && capture.read(frame)) {
         show_frame();
         this->msleep(delay);
 
@@ -206,7 +206,7 @@ int video_player::get_num_frames() {
  * @return The number of the currently read frame.
  */
 int video_player::get_current_frame_num() {
-    // capture.get() gives the number of the next frame, hence the compensation of -1.
+    // capture.get() gives the number of the frame to be read, hence the compensation of -1.
     return capture.get(CV_CAP_PROP_POS_FRAMES) - 1;
 }
 
@@ -215,8 +215,10 @@ int video_player::get_current_frame_num() {
  * @param frame_nbr The number to set the currently read frame to.
  */
 void video_player::set_current_frame_num(int frame_nbr) {
-    // capture.set() sets the number of the next frame, hence the compensation of +1.
-    capture.set(CV_CAP_PROP_POS_FRAMES, frame_nbr + 1);
+    if ((frame_nbr + 1) >= 0 && (frame_nbr + 1) < get_num_frames()) {
+        // capture.set() sets the number of the frame to be read, hence the compensation of +1.
+        capture.set(CV_CAP_PROP_POS_FRAMES, frame_nbr + 1);
+    }
 }
 
 /**

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -215,9 +215,11 @@ int video_player::get_current_frame_num() {
  * @param frame_nbr The number to set the currently read frame to.
  */
 void video_player::set_current_frame_num(int frame_nbr) {
-    if ((frame_nbr + 1) >= 0 && (frame_nbr + 1) < get_num_frames()) {
-        // capture.set() sets the number of the frame to be read, hence the compensation of +1.
-        capture.set(CV_CAP_PROP_POS_FRAMES, frame_nbr + 1);
+    // capture.set() sets the number of the frame to be read, hence the compensation of +1.
+    frame_nxt = frame_nbr + 1;
+    if (frame_nxt >= 0 && frame_nxt < get_num_frames()) {
+
+        capture.set(CV_CAP_PROP_POS_FRAMES, frame_nxt);
     }
 }
 

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -203,9 +203,7 @@ int video_player::get_num_frames() {
 
 /**
  * @brief video_player::get_current_frame_num
- * @return The number of the currently read frame.
- *         The index is 0-based, and -1 if the first
- *         frame has not been read yet.
+ * @return The number of the currently read frame (0-based index).
  */
 int video_player::get_current_frame_num() {
     // capture.get() gives the number of the frame to be read, hence the compensation of -1.
@@ -214,9 +212,7 @@ int video_player::get_current_frame_num() {
 
 /**
  * @brief video_player::set_current_frame_num
- * @param frame_nbr The number to set the currently read frame to.
- *        The index is 0-based, and -1 sets the playback to start
- *        from the first frame (i.e. frame 0 is the frame to be read next).
+ * @param frame_nbr The number to set the currently read frame to (0-based index).
  */
 void video_player::set_current_frame_num(int frame_nbr) {
     if (frame_nbr >= 0 && frame_nbr < get_num_frames()) {

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -206,7 +206,7 @@ int video_player::get_num_frames() {
  * @return The number of the current frame.
  */
 int video_player::get_current_frame_num() {
-    // capture.get() gives the number of the next frame, hence the -1.
+    // capture.get() gives the number of the next frame, hence the compensation of -1.
     return capture.get(CV_CAP_PROP_POS_FRAMES) - 1;
 }
 
@@ -215,7 +215,7 @@ int video_player::get_current_frame_num() {
  * @param frame_nbr The number to set the current frame to.
  */
 void video_player::set_current_frame_num(int frame_nbr) {
-    // capture.set() sets the number of the next frame, hence the +1.
+    // capture.set() sets the number of the next frame, hence the compensation of +1.
     capture.set(CV_CAP_PROP_POS_FRAMES, frame_nbr + 1);
 }
 
@@ -299,7 +299,7 @@ void video_player::on_stop_video() {
  * Updates the current frame if frame_nbr is valid.
  */
 void video_player::update_frame(int frame_nbr) {
-    // capture.read() will advance the video one frame, hence -1.
+    // capture.read() will advance the video one frame, hence compensation of -1.
     if (set_playback_frame(frame_nbr - 1)) {
         set_current_frame_num(frame_nbr - 1);
         capture.read(frame);

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -72,7 +72,7 @@ void video_player::run()  {
     video_paused = false;
     int delay = (1000/frame_rate);
     capture.set(CV_CAP_PROP_POS_FRAMES, current_frame);
-    while(!video_stopped && capture.read(frame)) {
+    while (!video_stopped && capture.read(frame)) {
         show_frame();
         this->msleep(delay);
 

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -72,7 +72,7 @@ void video_player::run()  {
     video_paused = false;
     int delay = (1000/frame_rate);
     capture.set(CV_CAP_PROP_POS_FRAMES, current_frame);
-    while(!video_stopped  && capture.read(frame)){
+    while(!video_stopped && capture.read(frame)){
         show_frame();
         this->msleep(delay);
 
@@ -203,7 +203,7 @@ int video_player::get_num_frames() {
 
 /**
  * @brief video_player::get_current_frame_num
- * @return The number of the current frame.
+ * @return The number of the currently read frame.
  */
 int video_player::get_current_frame_num() {
     // capture.get() gives the number of the next frame, hence the compensation of -1.
@@ -212,7 +212,7 @@ int video_player::get_current_frame_num() {
 
 /**
  * @brief video_player::set_current_frame_num
- * @param frame_nbr The number to set the current frame to.
+ * @param frame_nbr The number to set the currently read frame to.
  */
 void video_player::set_current_frame_num(int frame_nbr) {
     // capture.set() sets the number of the next frame, hence the compensation of +1.

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -204,6 +204,8 @@ int video_player::get_num_frames() {
 /**
  * @brief video_player::get_current_frame_num
  * @return The number of the currently read frame.
+ *         The index is 0-based, and -1 if the first
+ *         frame has not been read yet.
  */
 int video_player::get_current_frame_num() {
     // capture.get() gives the number of the frame to be read, hence the compensation of -1.
@@ -213,13 +215,15 @@ int video_player::get_current_frame_num() {
 /**
  * @brief video_player::set_current_frame_num
  * @param frame_nbr The number to set the currently read frame to.
+ *        The index is 0-based, and -1 sets the playback to start
+ *        from the first frame (i.e. frame 0 is the frame to be read next).
  */
 void video_player::set_current_frame_num(int frame_nbr) {
-    // capture.set() sets the number of the frame to be read, hence the compensation of +1.
-    frame_nxt = frame_nbr + 1;
-    if (frame_nxt >= 0 && frame_nxt < get_num_frames()) {
-
-        capture.set(CV_CAP_PROP_POS_FRAMES, frame_nxt);
+    if (frame_nbr >= 0 && frame_nbr < get_num_frames()) {
+        // capture.set() sets the number of the frame to be read.
+        capture.set(CV_CAP_PROP_POS_FRAMES, frame_nbr);
+        // capture.read() will read the frame and advance one step.
+        capture.read(frame);
     }
 }
 
@@ -303,10 +307,8 @@ void video_player::on_stop_video() {
  * Updates the current frame if frame_nbr is valid.
  */
 void video_player::update_frame(int frame_nbr) {
-    // capture.read() will advance the video one frame, hence compensation of -1.
-    if (set_playback_frame(frame_nbr - 1)) {
-        set_current_frame_num(frame_nbr - 1);
-        capture.read(frame);
+    if (set_playback_frame(frame_nbr)) {
+        set_current_frame_num(frame_nbr);
         show_frame();
     }
 }

--- a/ViAn/Video/video_player.h
+++ b/ViAn/Video/video_player.h
@@ -32,6 +32,7 @@ public:
 
     int get_num_frames();    
     int get_current_frame_num();
+    void set_current_frame_num(int frame_nbr);
     void play_pause();
     void stop_video();
     void set_frame_width(int new_value);


### PR DESCRIPTION
Extracted current frame calculations to separate function. Also changed the `set_playback_frame` so that next/prev frame now works in connection with pausing a clip.