### PR TITLE
Removed unused code in video player

### DIFF
--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -546,7 +546,6 @@ void MainWindow::play_video() {
     mvideo_player->load_video(selectedVideo->name.toStdString());
     iconOnButtonHandler->set_icon("pause", ui->playPauseButton);
     video_slider->setMaximum(mvideo_player->get_num_frames());
-    mvideo_player->set_playback_frame(0);
 }
 
 /**

--- a/ViAn/Test/test_video_player.cpp
+++ b/ViAn/Test/test_video_player.cpp
@@ -39,10 +39,8 @@ void test_video_player::test_load_video() {
 void test_video_player::test_stop_video() {
     mvideo->video_paused = true;
     mvideo->video_stopped = false;
-    mvideo->current_frame = 50;
-    mvideo->stop_video();
+    mvideo->on_stop_video();
     QVERIFY(mvideo->video_stopped == true);
-    QVERIFY(mvideo->current_frame == 0);
     QVERIFY(mvideo->video_paused == false);
 }
 
@@ -77,14 +75,6 @@ void test_video_player::test_set_frame_width() {
 void test_video_player::test_set_frame_height() {
     mvideo->set_frame_height(50);
     QVERIFY(mvideo->frame_height == 50);
-}
-
-/**
- * @brief test_video_player::test_set_playback_frame
- */
-void test_video_player::test_set_playback_frame() {
-    mvideo->set_playback_frame(100);
-    QVERIFY(mvideo->current_frame == 100);
 }
 
 /**

--- a/ViAn/Test/test_video_player.h
+++ b/ViAn/Test/test_video_player.h
@@ -22,7 +22,6 @@ private slots:
     void test_get_num_frames();
     void test_set_frame_width();
     void test_set_frame_height();
-    void test_set_playback_frame();
     void test_next_frame();
     void test_previous_frame();
     void test_inc_playback_speed();

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -76,7 +76,6 @@ void video_player::run()  {
         // Waits for the video to be resumed
         m_mutex->lock();
         if (video_paused) {
-            current_frame = capture.get(CV_CAP_PROP_POS_FRAMES) - 1;
             m_paused_wait->wait(m_mutex);
             video_paused = false;
         }

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -50,18 +50,6 @@ bool video_player::load_video(string filename) {
 }
 
 /**
- * @brief video_player::stop_video
- * Sets stop related bools to their correct values and sets the current playback frame to be 0.
- */
-void video_player::stop_video() {
-    video_stopped = true;
-    set_current_frame_num(0);
-    if (video_paused) {
-        video_paused = false;
-    }
-}
-
-/**
  * @brief video_player::run
  * This function is called whenever the thread is started or put out of sleep.
  * It houses the main loop for fetching frames from the currently played
@@ -276,11 +264,14 @@ void video_player::on_pause_video() {
 /**
  * @brief on_stop_video
  * Slot function to be used from the GUI thread
- * Sets the stopped bool to true and the paused bool to false
+ * Sets the stopped bool to true and the paused bool to false.
+ * Sets playback frame to the start of the video and updates the GUI.
  */
 void video_player::on_stop_video() {
     video_stopped = true;
     video_paused = false;
+    set_current_frame_num(0);
+    show_frame();
 }
 
 /**

--- a/ViAn/Video/video_player.h
+++ b/ViAn/Video/video_player.h
@@ -32,12 +32,11 @@ public:
 
     int get_num_frames();    
     int get_current_frame_num();
-    void set_current_frame_num(int frame_nbr);
+    bool set_current_frame_num(int frame_nbr);
     void play_pause();
     void stop_video();
     void set_frame_width(int new_value);
     void set_frame_height(int new_value);
-    bool set_playback_frame(int frame_num);
     void next_frame();
     void previous_frame();
     void set_speed_multiplier(double mult);
@@ -92,7 +91,6 @@ private:
     cv::Mat RGBframe;
 
     int num_frames;
-    unsigned int current_frame = 0;
     unsigned int frame_width;
     unsigned int frame_height;
 

--- a/ViAn/Video/video_player.h
+++ b/ViAn/Video/video_player.h
@@ -34,7 +34,6 @@ public:
     int get_current_frame_num();
     bool set_current_frame_num(int frame_nbr);
     void play_pause();
-    void stop_video();
     void set_frame_width(int new_value);
     void set_frame_height(int new_value);
     void next_frame();


### PR DESCRIPTION
Functions `set_playback_frame` and `stop_video` is removed and variable `current_frame` is removed. The old stop functionality is added to the new `on_stop_video` function.