### PR TITLE
Added tests for contrast/brightness

### DIFF
--- a/ViAn/Test/test_video_player.cpp
+++ b/ViAn/Test/test_video_player.cpp
@@ -171,6 +171,38 @@ void test_video_player::test_set_overlay_colour() {
 }
 
 /**
+ * @brief test_video_player::test_set_contrast
+ */
+void test_video_player::test_set_contrast() {
+    // Values should be 0-255
+    mvideo->set_contrast(-10);
+    QVERIFY(mvideo->get_contrast() == 0);
+    mvideo->set_contrast(-0.01);
+    QVERIFY(mvideo->get_contrast() == 0);
+    mvideo->set_contrast(0);
+    QVERIFY(mvideo->get_contrast() == 0);
+    mvideo->set_contrast(1);
+    QVERIFY(mvideo->get_contrast() == 1);
+    mvideo->set_contrast(2);
+    QVERIFY(mvideo->get_contrast() == 2);
+    mvideo->set_contrast(126);
+    QVERIFY(mvideo->get_contrast() == 126);
+    mvideo->set_contrast(254);
+    QVERIFY(mvideo->get_contrast() == 254);
+    mvideo->set_contrast(255);
+    QVERIFY(mvideo->get_contrast() == 255);
+    mvideo->set_contrast(255.1);
+    QVERIFY(mvideo->get_contrast() == 255);
+    mvideo->set_contrast(270);
+    QVERIFY(mvideo->get_contrast() == 255);
+}
+
+void test_video_player::test_set_brightness() {
+    mvideo->set_brightness(126);
+    QVERIFY(mvideo->get_brightness() == 126);
+}
+
+/**
  * @brief test_video_player::test_video_open
  */
 void test_video_player::test_video_open() {

--- a/ViAn/Test/test_video_player.cpp
+++ b/ViAn/Test/test_video_player.cpp
@@ -198,8 +198,27 @@ void test_video_player::test_set_contrast() {
 }
 
 void test_video_player::test_set_brightness() {
+    // Values should be 0-255
+    mvideo->set_brightness(-10);
+    QVERIFY(mvideo->get_brightness() == 0);
+    mvideo->set_brightness(-0.01);
+    QVERIFY(mvideo->get_brightness() == 0);
+    mvideo->set_brightness(0);
+    QVERIFY(mvideo->get_brightness() == 0);
+    mvideo->set_brightness(1);
+    QVERIFY(mvideo->get_brightness() == 1);
+    mvideo->set_brightness(2);
+    QVERIFY(mvideo->get_brightness() == 2);
     mvideo->set_brightness(126);
     QVERIFY(mvideo->get_brightness() == 126);
+    mvideo->set_brightness(254);
+    QVERIFY(mvideo->get_brightness() == 254);
+    mvideo->set_brightness(255);
+    QVERIFY(mvideo->get_brightness() == 255);
+    mvideo->set_brightness(255.1);
+    QVERIFY(mvideo->get_brightness() == 255);
+    mvideo->set_brightness(270);
+    QVERIFY(mvideo->get_brightness() == 255);
 }
 
 /**

--- a/ViAn/Test/test_video_player.h
+++ b/ViAn/Test/test_video_player.h
@@ -31,6 +31,8 @@ private slots:
     void test_toggle_overlay();
     void test_set_overlay_tool();
     void test_set_overlay_colour();
+    void test_set_contrast();
+    void test_set_brightness();
     void test_video_open();
     void test_scaling_event();
     void test_scale_frame();

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -208,12 +208,19 @@ cv::Mat video_player::contrast_frame(cv::Mat &frame) {
     // Create image for the modified frame.
     Mat modified_frame = Mat::zeros(frame.size(), frame.type());
 
+    double alpha = 1; /* Simple contrast control, alpha value [1.0-3.0]. */
+    double beta = 0;  /* Simple brightness control, beta value [0-100]. */
+    beta = 100 * brightness / 255.0;
+    // Alpha value in [1.0-3.0].
+    alpha = 1 + 2 * contrast / 255.0;
+    // Beta value in [0-100].
+
     // Do the operation new_image(i,j) = alpha*image(i,j) + beta
     for (int y = 0; y < frame.rows; y++) {
         for (int x = 0; x < frame.cols; x++) {
             for (int c = 0; c < 3; c++) {
                 modified_frame.at<Vec3b>(y, x)[c] =
-                    saturate_cast<uchar>(alpha * (frame.at<Vec3b>(y, x)[c]) + beta);
+                    saturate_cast<uchar>(alpha * (frame.at<Vec3b>(y, x)[c]) + (int)beta);
             }
         }
     }
@@ -393,10 +400,8 @@ void video_player::update_overlay() {
  * Sets the contrast value (alpha value).
  * @param contrast Contrast parameter in range 0 to 255.
  */
-void video_player::set_contrast(double contrast) {
-    contrast = std::min(255.0, std::max(0.0, contrast));
-    // Alpha value in [1.0-3.0].
-    alpha = 1 + 2 * contrast / 255.0;
+void video_player::set_contrast(int c) {
+    contrast = std::min(255, std::max(0, c));
 }
 
 /**
@@ -404,26 +409,24 @@ void video_player::set_contrast(double contrast) {
  * Sets the brightness value (beta value).
  * @param brightness Brightness parameter in range 0 to 255.
  */
-void video_player::set_brightness(double brightness) {
-    // Beta value in [0-100].
-    brightness = std::min(255.0, std::max(0.0, brightness));
-    beta = 100 * brightness / 255.0;
+void video_player::set_brightness(int b) {
+    brightness = std::min(255, std::max(0, b));
 }
 
 /**
  * @brief video_player::get_contrast
- * @return Returns contrast parameter in range 0 to 255
+ * @return Returns contrast parameter in range 0 to 255.
  */
 int video_player::get_contrast() {
-    return 255 * (alpha - 1) / 2;
+    return contrast;
 }
 
 /**
  * @brief video_player::get_brightness
- * @return Returns brightness parameter in range 0 to 255
+ * @return Returns brightness parameter in range 0 to 255.
  */
 int video_player::get_brightness() {
-    return 255 * ((double) beta / 100);
+    return brightness;
 }
 
 /**

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -208,19 +208,17 @@ cv::Mat video_player::contrast_frame(cv::Mat &frame) {
     // Create image for the modified frame.
     Mat modified_frame = Mat::zeros(frame.size(), frame.type());
 
-    double alpha = 1; /* Simple contrast control, alpha value [1.0-3.0]. */
-    double beta = 0;  /* Simple brightness control, beta value [0-100]. */
-    beta = 100 * brightness / 255.0;
-    // Alpha value in [1.0-3.0].
-    alpha = 1 + 2 * contrast / 255.0;
-    // Beta value in [0-100].
+    // Contrast control, alpha value in [1.0-3.0].
+    double alpha = 1 + 2 * contrast / 255.0;
+    // Brightness control, beta value in [0-100].
+    int beta = 100 * brightness / 255.0;
 
     // Do the operation new_image(i,j) = alpha*image(i,j) + beta
     for (int y = 0; y < frame.rows; y++) {
         for (int x = 0; x < frame.cols; x++) {
             for (int c = 0; c < 3; c++) {
                 modified_frame.at<Vec3b>(y, x)[c] =
-                    saturate_cast<uchar>(alpha * (frame.at<Vec3b>(y, x)[c]) + (int)beta);
+                    saturate_cast<uchar>(alpha * (frame.at<Vec3b>(y, x)[c]) + beta);
             }
         }
     }

--- a/ViAn/Video/video_player.h
+++ b/ViAn/Video/video_player.h
@@ -46,8 +46,8 @@ public:
     void inc_playback_speed();
     void dec_playback_speed();
     
-    void set_contrast(double contrast);
-    void set_brightness(double brightness);
+    void set_contrast(int contrast);
+    void set_brightness(int brightness);
     int get_contrast();
     int get_brightness();
     void toggle_overlay();
@@ -119,8 +119,8 @@ private:
 
     ZoomRectangle* zoom_area = new ZoomRectangle();
 
-    double alpha = 1; /* Simple contrast control, alpha value [1.0-3.0]. */
-    int beta = 0;     /* Simple brightness control, beta value [0-100]. */
+    int contrast = 0;   /* Value in range [0-255]. */
+    int brightness = 0; /* Value in range [0-255]. */
 
     Overlay* video_overlay;
 };


### PR DESCRIPTION
Added tests for contrast and brightness, and changed the representation on these values in the videoplayer. Now the 0-255 values are stored in the video player and recalculated to alpha and beta values in the contrast-function, instead of being calculated in the getters and setters.