### PR TITLE
Fixed overlay with new scaling functionality

### DIFF
--- a/ViAn/Video/video_player.h
+++ b/ViAn/Video/video_player.h
@@ -105,6 +105,8 @@ private:
     unsigned int current_frame = 0;
     unsigned int frame_width;
     unsigned int frame_height;
+    unsigned int qlabel_width;
+    unsigned int qlabel_height;
 
     double frame_rate;
     double speed_multiplier = DEFAULT_SPEED_MULT;


### PR DESCRIPTION
Fixed the drawing on the overlay to work with the new way of scaling the frame. To do this `scale_position()` is updated to handle the empty parts of the QLabel that is left when the QLabel don't have the same ratio as the video. Also needed to add new variables to remember the QLabel size in the videoplayer.