### PR TITLE
Added so that the zoom area follows the ratio of the video.

### DIFF
--- a/ViAn/Video/shapes/zoomrectangle.cpp
+++ b/ViAn/Video/shapes/zoomrectangle.cpp
@@ -23,7 +23,29 @@ ZoomRectangle::ZoomRectangle(QPoint pos) : Rectangle(QColor(0, 255, 0), pos) {
  */
 void ZoomRectangle::update_drawing_pos(QPoint pos) {
     // The zoom area has to be inside the video.
-    draw_end = bounded_coords(pos);
+    cv::Point bounded_pos = bounded_coords(pos);
+    // Calculate the ratio between the choosen area and the video.
+    double width_ratio = (double) std::abs(bounded_pos.x - draw_start.x)/width_video;
+    double height_ratio = (double) std::abs(bounded_pos.y - draw_start.y)/height_video;
+    // Set the area to follow the smallest ratio.
+    if (width_ratio >= height_ratio) {
+        draw_end.x = draw_start.x + width_video * height_ratio;
+        draw_end.y = bounded_pos.y;
+    } else {
+        draw_end.x = bounded_pos.x;
+        draw_end.y = draw_start.y + height_video * width_ratio;
+    }
+}
+
+/**
+ * @brief ZoomRectangle::reset_pos
+ * Resets the start and end mouse positions.
+ */
+void ZoomRectangle::reset_pos() {
+    draw_start.x = 0;
+    draw_start.y = 0;
+    draw_end.x = 0;
+    draw_end.y = 0;
 }
 
 /**

--- a/ViAn/Video/shapes/zoomrectangle.h
+++ b/ViAn/Video/shapes/zoomrectangle.h
@@ -8,6 +8,7 @@ public:
     ZoomRectangle();
     ZoomRectangle(QPoint pos);
     void set_start_pos(QPoint pos);
+    void reset_pos();
     void update_drawing_pos(QPoint pos);
     void choose_area();
     cv::Rect get_zoom_area();

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -525,6 +525,7 @@ void video_player::clear_overlay() {
 void video_player::zoom_in() {
     if (capture.isOpened()) {
         choosing_zoom_area = true;
+        zoom_area->reset_pos();
     }
 }
 


### PR DESCRIPTION
Now the zoom area follows the ratio of the video. The calculation is done when the mouse is moved and the position is updated in ZoomRectangle.
Also added so that the zoom area is reset when the user starts a zoom procedure.