### PR TITLE
Added tests for video next/previous frame

### DIFF
--- a/ViAn/Test/test_video_player.cpp
+++ b/ViAn/Test/test_video_player.cpp
@@ -32,19 +32,6 @@ void test_video_player::test_load_video() {
 }
 
 /**
- * @brief test_video_player::test_stop_video
- * Tests ONLY the case when the video is paused because if the video
- * is running, the stop related commands are executed on another thread.
- */
-void test_video_player::test_stop_video() {
-    mvideo->video_paused = true;
-    mvideo->video_stopped = false;
-    mvideo->on_stop_video();
-    QVERIFY(mvideo->video_stopped == true);
-    QVERIFY(mvideo->video_paused == false);
-}
-
-/**
  * @brief test_video_player::test_is_paused
  */
 void test_video_player::test_is_paused() {
@@ -78,29 +65,32 @@ void test_video_player::test_set_frame_height() {
 }
 
 /**
+ * @brief test_video_player::test_set_current_frame
+ */
+void test_video_player::test_set_current_frame() {
+    mvideo->set_current_frame_num(100);
+    QVERIFY(mvideo->get_current_frame_num() == 100);
+    mvideo->set_current_frame_num(10);
+    mvideo->set_current_frame_num(-10);
+    QVERIFY(mvideo->get_current_frame_num() == 10);
+}
+
+/**
  * @brief test_video_player::test_next_frame
- * Currently this method cannot be tested because of thread issues.
  */
 void test_video_player::test_next_frame() {
-    /*
-    mvideo->load_video("seq_01.mp4");
-    mvideo->set_playback_frame(100);
+    mvideo->set_current_frame_num(100);
     mvideo->next_frame();
-    QVERIFY(mvideo->current_frame == 101);
-    */
+    QVERIFY(mvideo->get_current_frame_num() == 101);
 }
 
 /**
  * @brief test_video_player::test_previous_frame
- * Currently this method cannot be tested because of thread issues.
  */
 void test_video_player::test_previous_frame() {
-    /*
-    mvideo->load_video("seq_01.mp4");
-    mvideo->set_playback_frame(100);
+    mvideo->set_current_frame_num(100);
     mvideo->previous_frame();
-    QVERIFY(mvideo->current_frame == 99);
-    */
+    QVERIFY(mvideo->get_current_frame_num() == 99);
 }
 
 /**
@@ -137,6 +127,7 @@ void test_video_player::test_dec_playback_speed(){
  * @brief test_toggle_overlay
  */
 void test_video_player::test_toggle_overlay() {
+    mvideo->on_stop_video();
     mvideo->video_overlay->set_showing_overlay(false);
     mvideo->toggle_overlay();
     QVERIFY(mvideo->is_showing_overlay());
@@ -188,5 +179,6 @@ void test_video_player::test_set_stop_video() {
     mvideo->video_stopped = false;
     mvideo->on_stop_video();
     QVERIFY(!mvideo->video_paused);
+    QVERIFY(mvideo->get_current_frame_num() == 0);
     QVERIFY(mvideo->video_stopped);
 }

--- a/ViAn/Test/test_video_player.h
+++ b/ViAn/Test/test_video_player.h
@@ -22,11 +22,11 @@ private slots:
     void test_get_num_frames();
     void test_set_frame_width();
     void test_set_frame_height();
+    void test_set_current_frame();
     void test_next_frame();
     void test_previous_frame();
     void test_inc_playback_speed();
     void test_dec_playback_speed();
-    void test_stop_video();
     void test_toggle_overlay();
     void test_set_overlay_tool();
     void test_set_overlay_colour();

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -76,7 +76,6 @@ void video_player::run()  {
         // Waits for the video to be resumed
         m_mutex->lock();
         if (video_paused) {
-            current_frame = capture.get(CV_CAP_PROP_POS_FRAMES) - 1;
             m_paused_wait->wait(m_mutex);
             video_paused = false;
         }


### PR DESCRIPTION
Added test for the new `set_current_frame` function. Fixed the next/previous frame tests. (Also changed video overlay test, because it requires the video to be stopped.)