### PR TITLE
Added simple analysis area tool

### DIFF
--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -765,3 +765,16 @@ void MainWindow::enable_video_buttons() {
     ui->previousFrameButton->setEnabled(true);
     ui->stopButton->setEnabled(true);
 }
+
+/**
+ * @brief MainWindow::on_actionShow_hide_analysis_area_triggered
+ * Toggles the choosing of an analysis area.
+ */
+void MainWindow::on_actionShow_hide_analysis_area_triggered() {
+    mvideo_player->toggle_analysis_area();
+    if (mvideo_player->is_showing_analysis_tool()) {
+        set_status_bar("Showing analysis area tool. Select your area by clicking on the video.");
+    } else {
+        set_status_bar("Hiding analysis area tool.");
+    }
+}

--- a/ViAn/GUI/mainwindow.h
+++ b/ViAn/GUI/mainwindow.h
@@ -125,6 +125,7 @@ private slots:
 
     void on_actionDeleteProject_triggered();
 
+    void on_actionShow_hide_analysis_area_triggered();
 
 private:
 

--- a/ViAn/GUI/mainwindow.ui
+++ b/ViAn/GUI/mainwindow.ui
@@ -314,7 +314,7 @@
      <x>0</x>
      <y>0</y>
      <width>616</width>
-     <height>20</height>
+     <height>19</height>
     </rect>
    </property>
    <property name="mouseTracking">
@@ -366,6 +366,7 @@
     <addaction name="actionShow_hide_overlay"/>
     <addaction name="actionZoom_in"/>
     <addaction name="actionZoom_out"/>
+    <addaction name="actionShow_hide_analysis_area"/>
    </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
@@ -664,6 +665,11 @@
   <action name="actionChoose_Workspace">
    <property name="text">
     <string>Choose Workspace</string>
+   </property>
+  </action>
+  <action name="actionShow_hide_analysis_area">
+   <property name="text">
+    <string>Show/hide analysis area</string>
    </property>
   </action>
  </widget>

--- a/ViAn/ViAn.pro
+++ b/ViAn/ViAn.pro
@@ -64,7 +64,8 @@ SOURCES += Video/video_player.cpp \
     Video/shapes/rectangle.cpp \
     Video/shapes/shape.cpp \
     Video/shapes/text.cpp \
-    Video/shapes/zoomrectangle.cpp
+    Video/shapes/zoomrectangle.cpp \
+    Video/shapes/analysarea.cpp
 HEADERS += Video/video_player.h \
     Video/overlay.h \
     Video/shapes/arrow.h \
@@ -74,7 +75,8 @@ HEADERS += Video/video_player.h \
     Video/shapes/rectangle.h \
     Video/shapes/shape.h \
     Video/shapes/text.h \
-    Video/shapes/zoomrectangle.h
+    Video/shapes/zoomrectangle.h \
+    Video/shapes/analysarea.h
 win32 {
     INCLUDEPATH += C:\opencv\release\install\include
     LIBS += C:\opencv\release\bin\libopencv_core320.dll

--- a/ViAn/Video/overlay.h
+++ b/ViAn/Video/overlay.h
@@ -11,6 +11,7 @@
 #include "shapes/pen.h"
 #include "shapes/text.h"
 #include "shapes/zoomrectangle.h"
+#include "shapes/analysarea.h"
 
 #include "opencv2/opencv.hpp"
 

--- a/ViAn/Video/shapes/analysarea.cpp
+++ b/ViAn/Video/shapes/analysarea.cpp
@@ -1,0 +1,20 @@
+#include "analysarea.h"
+
+AnalysArea::AnalysArea() {
+
+}
+
+/**
+ * @brief AnalysArea::draw
+ * Draws the object on top of the specified frame.
+ * @param frame Frame to draw on.
+ * @return Returns the frame with drawing.
+ */
+cv::Mat AnalysArea::draw(cv::Mat &frame) {
+
+    return frame;
+}
+
+void AnalysArea::add_point(QPoint pos) {
+}
+

--- a/ViAn/Video/shapes/analysarea.cpp
+++ b/ViAn/Video/shapes/analysarea.cpp
@@ -1,7 +1,6 @@
 #include "analysarea.h"
 
 AnalysArea::AnalysArea() {
-
 }
 
 /**
@@ -11,10 +10,13 @@ AnalysArea::AnalysArea() {
  * @return Returns the frame with drawing.
  */
 cv::Mat AnalysArea::draw(cv::Mat &frame) {
-
+    for (std::pair<cv::Point, cv::Point> line : lines) {
+        cv::line(frame, line.first, line.second, colour, LINE_THICKNESS);
+    }
     return frame;
 }
 
 void AnalysArea::add_point(QPoint pos) {
+    points.push_back(Shape::qpoint_to_point(pos));
 }
 

--- a/ViAn/Video/shapes/analysarea.cpp
+++ b/ViAn/Video/shapes/analysarea.cpp
@@ -1,6 +1,16 @@
 #include "analysarea.h"
 
+/**
+ * @brief AnalysArea::AnalysArea
+ */
 AnalysArea::AnalysArea() {
+}
+
+/**
+ * @brief AnalysArea::~AnalysArea
+ */
+AnalysArea::~AnalysArea() {
+    delete points;
 }
 
 /**
@@ -10,13 +20,38 @@ AnalysArea::AnalysArea() {
  * @return Returns the frame with drawing.
  */
 cv::Mat AnalysArea::draw(cv::Mat &frame) {
-    for (std::pair<cv::Point, cv::Point> line : lines) {
-        cv::line(frame, line.first, line.second, colour, LINE_THICKNESS);
+    int size = points->size();
+    // The drawing requires at least one point to draw.
+    if (size > 0) {
+        cv::Point rook_points[1][size];
+
+        // Copy the frame.
+        cv::Mat area;
+        frame.copyTo(area);
+
+        // Create array of points for the polygon.
+        for (int i = 0; i < size; i++) {
+            rook_points[0][i] = points->at(i);
+        }
+        const cv::Point* ppt[1] = {rook_points[0]};
+        int npt[] = {size};
+
+        // Draw polygon on the copied frame.
+        cv::fillPoly(area, ppt, npt, 1, cv::Scalar(255, 255, 255));
+        cv::polylines(area, ppt, npt, 1, true, cv::Scalar(255, 0, 0), Shape::LINE_THICKNESS);
+
+        // Add opacity and blend with the original frame.
+        double alpha = 0.6;
+        cv::addWeighted(area, alpha, frame, 1.0 - alpha , 0.0, frame);
     }
     return frame;
 }
 
+/**
+ * @brief AnalysArea::add_point
+ * Adds point to the area that should be selected.
+ * @param pos The new position to be added.
+ */
 void AnalysArea::add_point(QPoint pos) {
-    points.push_back(Shape::qpoint_to_point(pos));
+    points->push_back(Shape::qpoint_to_point(pos));
 }
-

--- a/ViAn/Video/shapes/analysarea.h
+++ b/ViAn/Video/shapes/analysarea.h
@@ -7,9 +7,11 @@
 class AnalysArea {
 public:
     AnalysArea();
+    ~AnalysArea();
+    cv::Mat draw(cv::Mat &frame);
     void add_point(QPoint pos);
 private:
-    std::vector<cv::Point> points;
+    std::vector<cv::Point>* points = new std::vector<cv::Point>();
 };
 
 #endif // ANALYSAREA_H

--- a/ViAn/Video/shapes/analysarea.h
+++ b/ViAn/Video/shapes/analysarea.h
@@ -1,0 +1,15 @@
+#ifndef ANALYSAREA_H
+#define ANALYSAREA_H
+
+#include "opencv2/opencv.hpp"
+#include "shape.h"
+
+class AnalysArea {
+public:
+    AnalysArea();
+    void add_point(QPoint pos);
+private:
+    std::vector<cv::Point> points;
+};
+
+#endif // ANALYSAREA_H

--- a/ViAn/Video/shapes/shape.h
+++ b/ViAn/Video/shapes/shape.h
@@ -16,12 +16,13 @@ public:
     void update_drawing_pos(QPoint pos);
     virtual void handle_new_pos(QPoint pos) = 0;
     virtual cv::Mat draw(cv::Mat &frame) = 0;
-protected:
-    int LINE_THICKNESS = 2;
 
     static cv::Scalar qcolor_to_scalar(QColor col);
     static cv::Point qpoint_to_point(QPoint pnt);
 
+    static const int LINE_THICKNESS = 2;
+
+protected:
     cv::Scalar colour;
     cv::Point draw_start;
     cv::Point draw_end;

--- a/ViAn/Video/shapes/shape.h
+++ b/ViAn/Video/shapes/shape.h
@@ -19,8 +19,8 @@ public:
 protected:
     int LINE_THICKNESS = 2;
 
-    cv::Scalar qcolor_to_scalar(QColor col);
-    cv::Point qpoint_to_point(QPoint pnt);
+    static cv::Scalar qcolor_to_scalar(QColor col);
+    static cv::Point qpoint_to_point(QPoint pnt);
 
     cv::Scalar colour;
     cv::Point draw_start;

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -25,7 +25,6 @@ video_player::video_player(QMutex* mutex, QWaitCondition* paused_wait, QObject* 
  */
 video_player::~video_player() {
     delete video_overlay;
-    delete zoom_area;
     delete analysis_area;
     capture.release();
 }

--- a/ViAn/Video/video_player.h
+++ b/ViAn/Video/video_player.h
@@ -28,6 +28,7 @@ public:
     bool is_paused();
     bool is_stopped();
     bool is_showing_overlay();
+    bool is_showing_analysis_tool();
     void export_current_frame(QString path_to_folder);
     bool video_open();
 
@@ -53,6 +54,7 @@ public:
     void set_overlay_colour(QColor colour);
     void undo_overlay();
     void clear_overlay();
+    void toggle_analysis_area();
     void zoom_in();
     void zoom_out();
     void video_mouse_pressed(QPoint pos);
@@ -111,12 +113,14 @@ private:
     bool video_stopped = false;
     bool video_paused;
     bool choosing_zoom_area = false;
+    bool choosing_analysis_area = false;
 
     QImage img;
     QMutex* m_mutex;
     QWaitCondition* m_paused_wait;
 
     ZoomRectangle* zoom_area = new ZoomRectangle();
+    AnalysArea* analysis_area = new AnalysArea();
 
     int contrast = 0;   /* Value in range [0-255]. */
     int brightness = 0; /* Value in range [0-255]. */


### PR DESCRIPTION
Added a simple tool for choosing an area. It's not connected to anything yet, only shown on the frame. It uses a new class which draws a polygon between a list of points that the user selects by clicking on the video while in the analysis-area-tool-mode (chosen through en option in View-menu). You can not remove any points you've chosen or start over with the area, you can only hide or show it (which is the same as being able to edit it or not being able to edit it).