### PR TITLE
Selectable text font scale option

### DIFF
--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -51,7 +51,8 @@ void Overlay::set_showing_overlay(bool value) {
 /**
  * @brief Overlay::set_tool
  * Sets the overlay tool's shape.
- * If the tool is the text-tool the user is prompted to wnter a text.
+ * If the tool is the text-tool the user is prompted
+ * to enter a text and a font scale.
  * @param s
  */
 void Overlay::set_tool(SHAPES s) {

--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -55,15 +55,27 @@ void Overlay::set_showing_overlay(bool value) {
  * @param s
  */
 void Overlay::set_tool(SHAPES s) {
+    current_shape = s;
+
+    // If the text option is choosen, a string and size will be entered by the user.
     if (s == TEXT) {
-        bool ok;
-        current_string = QInputDialog::getText(NULL, "Text chooser", "Enter a text:", QLineEdit::Normal, QString(), &ok);
-        if (!ok || current_string.isEmpty()) {
-            // Cancelled or empty field.
-            return;
+        std::string input_string = current_string.toStdString();
+        float input_font_scale = current_font_scale;
+        CustomDialog dialog("Choose text", NULL);
+        dialog.addLabel("Enter values:");
+        dialog.addLineEdit ("Text:", &input_string, "Enter a text that can then be used to draw on the overlay.");
+        dialog.addDblSpinBoxF("Font scale:", 0.5, 5.0, &input_font_scale, 1, 0.1,
+                              "Choose font scale, 0.5 to 5.0 (this value is multiplied with a default font size).");
+
+        // Show the dialog (execution will stop here until the dialog is finished)
+        dialog.exec();
+
+        if (!dialog.wasCancelled() && !input_string.empty()) {
+            // Not cancelled and not empty field.
+            current_string = QString::fromStdString(input_string);
+            current_font_scale = input_font_scale;
         }
     }
-    current_shape = s;
 }
 
 /**
@@ -117,7 +129,7 @@ void Overlay::mouse_pressed(QPoint pos, int frame_nr) {
                 overlays[frame_nr].append(new Pen(current_colour, pos));
                 break;
             case TEXT:
-                overlays[frame_nr].append(new Text(current_colour, pos, current_string));
+                overlays[frame_nr].append(new Text(current_colour, pos, current_string, current_font_scale));
                 break;
             default:
                 break;

--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -65,7 +65,8 @@ void Overlay::set_tool(SHAPES s) {
         CustomDialog dialog("Choose text", NULL);
         dialog.addLabel("Enter values:");
         dialog.addLineEdit ("Text:", &input_string, "Enter a text that can then be used to draw on the overlay.");
-        dialog.addDblSpinBoxF("Font scale:", 0.5, 5.0, &input_font_scale, 1, 0.1,
+        dialog.addDblSpinBoxF("Font scale:", Text::FONT_SCALE_MIN, Text::FONT_SCALE_MAX,
+                              &input_font_scale, Text::FONT_SCALE_DECIMALS, Text::FONT_SCALE_STEP,
                               "Choose font scale, 0.5 to 5.0 (this value is multiplied with a default font size).");
 
         // Show the dialog (execution will stop here until the dialog is finished)

--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -53,7 +53,7 @@ void Overlay::set_showing_overlay(bool value) {
  * Sets the overlay tool's shape.
  * If the tool is the text-tool the user is prompted
  * to enter a text and a font scale.
- * @param s
+ * @param s New tool to be set.
  */
 void Overlay::set_tool(SHAPES s) {
     current_shape = s;
@@ -82,7 +82,7 @@ void Overlay::set_tool(SHAPES s) {
 /**
  * @brief Overlay::set_colour
  * Sets the overlay tool's colour.
- * @param col
+ * @param col New colour to be set.
  */
 void Overlay::set_colour(QColor col) {
     current_colour = col;

--- a/ViAn/Video/overlay.h
+++ b/ViAn/Video/overlay.h
@@ -11,7 +11,7 @@
 #include "shapes/pen.h"
 #include "shapes/text.h"
 #include "shapes/zoomrectangle.h"
-
+#include "Library/customdialog.h"
 #include "opencv2/opencv.hpp"
 
 class Overlay {
@@ -39,7 +39,8 @@ private:
 
     SHAPES current_shape = RECTANGLE;
     QColor current_colour = Qt::red;
-    QString current_string = "";
+    QString current_string = "Enter text";
+    float current_font_scale = 1;
 
     std::map<int, QList<Shape*>> overlays;
 };

--- a/ViAn/Video/shapes/text.cpp
+++ b/ViAn/Video/shapes/text.cpp
@@ -4,6 +4,8 @@
  * @brief Text::Text
  * @param col Colour of the new object
  * @param pos Starting point for the new object
+ * @param strng String to be displayed
+ * @param fnt_scl Font scale of the string
  */
 Text::Text(QColor col, QPoint pos, QString strng, double fnt_scl) : Shape(col, pos) {
     string = strng;

--- a/ViAn/Video/shapes/text.cpp
+++ b/ViAn/Video/shapes/text.cpp
@@ -5,8 +5,9 @@
  * @param col Colour of the new object
  * @param pos Starting point for the new object
  */
-Text::Text(QColor col, QPoint pos, QString strng) : Shape(col, pos) {
+Text::Text(QColor col, QPoint pos, QString strng, double fnt_scl) : Shape(col, pos) {
     string = strng;
+    font_scale = fnt_scl;
 }
 
 /**
@@ -16,7 +17,7 @@ Text::Text(QColor col, QPoint pos, QString strng) : Shape(col, pos) {
  * @return Returns the frame with drawing.
  */
 cv::Mat Text::draw(cv::Mat &frame) {
-    cv::putText(frame, string.toStdString(), draw_end, cv::FONT_HERSHEY_SIMPLEX, FONT_SCALE,
+    cv::putText(frame, string.toStdString(), draw_end, cv::FONT_HERSHEY_SIMPLEX, font_scale,
                 colour, LINE_THICKNESS);
     return frame;
 }

--- a/ViAn/Video/shapes/text.h
+++ b/ViAn/Video/shapes/text.h
@@ -5,12 +5,12 @@
 
 class Text : public Shape {
 public:
-    Text(QColor col, QPoint pos, QString strng);
+    Text(QColor col, QPoint pos, QString strng, double fnt_scl);
     cv::Mat draw(cv::Mat &frame) override;
     void handle_new_pos(QPoint pos) override;
 private:
-    const int FONT_SCALE = 1;
     QString string;
+    double font_scale = 1;
 };
 
 #endif // TEXT_H

--- a/ViAn/Video/shapes/text.h
+++ b/ViAn/Video/shapes/text.h
@@ -9,7 +9,7 @@ public:
     cv::Mat draw(cv::Mat &frame) override;
     void handle_new_pos(QPoint pos) override;
 
-    // Constants describing the limit and presicion of the font scale value.
+    // Constants describing the limit and precision of the font scale value.
     static constexpr double FONT_SCALE_MIN = 0.5, FONT_SCALE_MAX = 5.0, FONT_SCALE_STEP = 0.1;
     static constexpr int FONT_SCALE_DECIMALS = 1;
 private:

--- a/ViAn/Video/shapes/text.h
+++ b/ViAn/Video/shapes/text.h
@@ -10,7 +10,7 @@ public:
     void handle_new_pos(QPoint pos) override;
 private:
     QString string;
-    double font_scale = 1;
+    double font_scale;
 };
 
 #endif // TEXT_H

--- a/ViAn/Video/shapes/text.h
+++ b/ViAn/Video/shapes/text.h
@@ -8,6 +8,10 @@ public:
     Text(QColor col, QPoint pos, QString strng, double fnt_scl);
     cv::Mat draw(cv::Mat &frame) override;
     void handle_new_pos(QPoint pos) override;
+
+    // Constants describing the limit and presicion of the font scale value.
+    static constexpr double FONT_SCALE_MIN = 0.5, FONT_SCALE_MAX = 5.0, FONT_SCALE_STEP = 0.1;
+    static constexpr int FONT_SCALE_DECIMALS = 1;
 private:
     QString string;
     double font_scale;


### PR DESCRIPTION
Added so that the user gets to choose font scale when entering a text (the font scale is used by opencv to multiply with the default font size, which is depending on what font is used). To do this, the CustomDialog class (found in Library) has been used.