### PR TITLE
Added zoom_area destructor

### DIFF
--- a/ViAn/Video/shapes/zoomrectangle.cpp
+++ b/ViAn/Video/shapes/zoomrectangle.cpp
@@ -14,6 +14,12 @@ ZoomRectangle::ZoomRectangle(QPoint pos) : Rectangle(QColor(0, 255, 0), pos) {
 }
 
 /**
+ * @brief ZoomRectangle::~ZoomRectangle
+ */
+ZoomRectangle::~ZoomRectangle() {
+}
+
+/**
  * @brief ZoomRectangle::update_drawing_pos
  * Updates the position of the end point of the drawing.
  * Coordinates outside the frame are moved to the closest

--- a/ViAn/Video/shapes/zoomrectangle.h
+++ b/ViAn/Video/shapes/zoomrectangle.h
@@ -7,6 +7,7 @@ class ZoomRectangle : public Rectangle {
 public:
     ZoomRectangle();
     ZoomRectangle(QPoint pos);
+    virtual ~ZoomRectangle();
     void set_start_pos(QPoint pos);
     void reset_pos();
     void update_drawing_pos(QPoint pos);

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -15,7 +15,6 @@ using namespace cv;
  * @param parent
  */
 video_player::video_player(QMutex* mutex, QWaitCondition* paused_wait, QObject* parent) : QThread(parent) {
-    video_overlay = new Overlay();
     m_mutex = mutex;
     m_paused_wait = paused_wait;
 }
@@ -25,6 +24,7 @@ video_player::video_player(QMutex* mutex, QWaitCondition* paused_wait, QObject* 
  */
 video_player::~video_player() {
     delete video_overlay;
+    delete zoom_area;
     capture.release();
 }
 

--- a/ViAn/Video/video_player.h
+++ b/ViAn/Video/video_player.h
@@ -129,7 +129,7 @@ private:
     // Brightness, value in range BRIGHTNESS_MIN to BRIGHTNESS_MAX.
     int beta = 0;
 
-    Overlay* video_overlay;
+    Overlay* video_overlay = new Overlay();
 };
 
 #endif // VIDEO_PLAYER_H


### PR DESCRIPTION
Added delete of the zoom_area in the video_player, and added a destructor in ZoomRectangle, because Qt was showing a warning about this. Also moved the initialization of the overlay to the headerfile to make the code more uniform.