### PR TITLE
Simple bookmark tool

### DIFF
--- a/ViAn/GUI/bookmarkview.cpp
+++ b/ViAn/GUI/bookmarkview.cpp
@@ -47,7 +47,7 @@ QString BookmarkView::get_input_text() {
     // Create the dialog
     CustomDialog dialog("Bookmark description", NULL);
     dialog.addLabel("Write a description of the bookmark:");
-    dialog.addTextEdit(&bookmark_text, false, false, TEXT_EDIT_HEIGHT,
+    dialog.addTextEdit(&bookmark_text, false, false, TEXT_EDIT_MIN_HEIGHT,
                           "Write a description of the bookmark. This will be used when creating a report.");
 
     // Show the dialog (execution will stop here until the dialog is finished)

--- a/ViAn/GUI/bookmarkview.cpp
+++ b/ViAn/GUI/bookmarkview.cpp
@@ -1,0 +1,24 @@
+#include "bookmarkview.h"
+#include <iostream>
+
+/**
+ * @brief BookmarkView::BookmarkView
+ * Constructor.
+ * @param parent Parent item of the BookmarkView.
+ */
+BookmarkView::BookmarkView(QListWidget* parent) {
+    view = parent;
+    view->addItem("Bookmarks:");
+}
+
+void BookmarkView::add_bookmark(std::string file_path) {
+    QImage img = QImage(QString::fromStdString(file_path), "TIFF");
+    img.scaledToHeight(BOOKMARK_HEIGHT);
+
+    QListWidgetItem *item = new QListWidgetItem("", view);
+    item->setData(Qt::DecorationRole, QPixmap::fromImage(img));
+
+    view->addItem(item);
+
+    //view->addItem(QString::fromStdString(file_path));
+}

--- a/ViAn/GUI/bookmarkview.cpp
+++ b/ViAn/GUI/bookmarkview.cpp
@@ -28,7 +28,7 @@ int BookmarkView::get_num_bookmarks() {
  */
 void BookmarkView::add_bookmark(std::string file_path) {
     QImage img = QImage(QString::fromStdString(file_path), "TIFF");
-    img = img.scaledToHeight(BOOKMARK_HEIGHT);
+    img = img.scaledToHeight(BOOKMARK_THUMBNAIL_HEIGHT);
 
     QListWidgetItem *item = new QListWidgetItem(get_input_text(), view);
     item->setData(Qt::DecorationRole, QPixmap::fromImage(img));

--- a/ViAn/GUI/bookmarkview.cpp
+++ b/ViAn/GUI/bookmarkview.cpp
@@ -34,8 +34,6 @@ void BookmarkView::add_bookmark(std::string file_path) {
     item->setData(Qt::DecorationRole, QPixmap::fromImage(img));
 
     view->addItem(item);
-
-    //view->addItem(QString::fromStdString(file_path));
 }
 
 /**
@@ -44,8 +42,6 @@ void BookmarkView::add_bookmark(std::string file_path) {
  *         obtained from the user.
  */
 QString BookmarkView::get_input_text() {
-
-    // Create the texts shown in the dialog
     std::string contrast_text = "";
 
     // Create the dialog

--- a/ViAn/GUI/bookmarkview.cpp
+++ b/ViAn/GUI/bookmarkview.cpp
@@ -30,18 +30,23 @@ void BookmarkView::add_bookmark(std::string file_path) {
     QImage img = QImage(QString::fromStdString(file_path), "TIFF");
     img = img.scaledToHeight(BOOKMARK_THUMBNAIL_HEIGHT);
 
-    QListWidgetItem *item = new QListWidgetItem(get_input_text(), view);
-    item->setData(Qt::DecorationRole, QPixmap::fromImage(img));
+    bool ok;
+    QString bookmark_text = get_input_text(&ok);
+    if (ok) {
+        QListWidgetItem *item = new QListWidgetItem(bookmark_text, view);
+        item->setData(Qt::DecorationRole, QPixmap::fromImage(img));
 
-    view->addItem(item);
+        view->addItem(item);
+    }
 }
 
 /**
  * @brief BookmarkView::get_input_text
+ * @param ok Parameter set to false if the user cancels.
  * @return Returns a description for the bookmark,
  *         obtained from the user.
  */
-QString BookmarkView::get_input_text() {
+QString BookmarkView::get_input_text(bool* ok) {
     std::string bookmark_text = "";
 
     // Create the dialog
@@ -54,8 +59,9 @@ QString BookmarkView::get_input_text() {
     dialog.exec();
 
     if (dialog.wasCancelled()) {
+        *ok = false;
         return "";
     }
-
+    *ok = true;
     return QString::fromStdString(bookmark_text);
 }

--- a/ViAn/GUI/bookmarkview.cpp
+++ b/ViAn/GUI/bookmarkview.cpp
@@ -1,4 +1,5 @@
 #include "bookmarkview.h"
+#include "Library/customdialog.h"
 #include <iostream>
 
 /**
@@ -11,14 +12,54 @@ BookmarkView::BookmarkView(QListWidget* parent) {
     view->addItem("Bookmarks:");
 }
 
+/**
+ * @brief BookmarkView::get_num_bookmarks
+ * @return Returns the number of bookmarks.
+ */
+int BookmarkView::get_num_bookmarks() {
+    return view->count();
+}
+
+/**
+ * @brief BookmarkView::add_bookmark
+ * Adds a bookmark containing an image (thumbnail)
+ * and a text description of the bookmark.
+ * @param file_path Path to the image of the bookmark.
+ */
 void BookmarkView::add_bookmark(std::string file_path) {
     QImage img = QImage(QString::fromStdString(file_path), "TIFF");
-    img.scaledToHeight(BOOKMARK_HEIGHT);
+    img = img.scaledToHeight(BOOKMARK_HEIGHT);
 
-    QListWidgetItem *item = new QListWidgetItem("", view);
+    QListWidgetItem *item = new QListWidgetItem(get_input_text(), view);
     item->setData(Qt::DecorationRole, QPixmap::fromImage(img));
 
     view->addItem(item);
 
     //view->addItem(QString::fromStdString(file_path));
+}
+
+/**
+ * @brief BookmarkView::get_input_text
+ * @return Returns a description for the bookmark,
+ *         obtained from the user.
+ */
+QString BookmarkView::get_input_text() {
+
+    // Create the texts shown in the dialog
+    std::string contrast_text = "";
+
+    // Create the dialog
+    CustomDialog dialog("Bookmark description", NULL);
+    dialog.addLabel("Write a description of the bookmark:");
+    dialog.addTextEdit(&contrast_text, false, false, TEXT_EDIT_HEIGHT,
+                          "Write a description of the bookmark. This will be used when creating a report.");
+
+    // Show the dialog (execution will stop here until the dialog is finished)
+    dialog.exec();
+
+    if (dialog.wasCancelled()) {
+        return "";
+    }
+
+    return QString::fromStdString(contrast_text);
 }

--- a/ViAn/GUI/bookmarkview.cpp
+++ b/ViAn/GUI/bookmarkview.cpp
@@ -42,12 +42,12 @@ void BookmarkView::add_bookmark(std::string file_path) {
  *         obtained from the user.
  */
 QString BookmarkView::get_input_text() {
-    std::string contrast_text = "";
+    std::string bookmark_text = "";
 
     // Create the dialog
     CustomDialog dialog("Bookmark description", NULL);
     dialog.addLabel("Write a description of the bookmark:");
-    dialog.addTextEdit(&contrast_text, false, false, TEXT_EDIT_HEIGHT,
+    dialog.addTextEdit(&bookmark_text, false, false, TEXT_EDIT_HEIGHT,
                           "Write a description of the bookmark. This will be used when creating a report.");
 
     // Show the dialog (execution will stop here until the dialog is finished)
@@ -57,5 +57,5 @@ QString BookmarkView::get_input_text() {
         return "";
     }
 
-    return QString::fromStdString(contrast_text);
+    return QString::fromStdString(bookmark_text);
 }

--- a/ViAn/GUI/bookmarkview.h
+++ b/ViAn/GUI/bookmarkview.h
@@ -9,7 +9,7 @@ public:
     void add_bookmark(std::string file_path);
     int get_num_bookmarks();
 private:
-    QString get_input_text();
+    QString get_input_text(bool* ok);
 
     const int BOOKMARK_THUMBNAIL_HEIGHT = 64;
     const int TEXT_EDIT_MIN_HEIGHT = 32;

--- a/ViAn/GUI/bookmarkview.h
+++ b/ViAn/GUI/bookmarkview.h
@@ -12,7 +12,7 @@ private:
     QString get_input_text();
 
     const int BOOKMARK_HEIGHT = 64;
-    const int TEXT_EDIT_HEIGHT = 32;
+    const int TEXT_EDIT_MIN_HEIGHT = 32;
 
     QListWidget* view;
 };

--- a/ViAn/GUI/bookmarkview.h
+++ b/ViAn/GUI/bookmarkview.h
@@ -1,0 +1,15 @@
+#ifndef BOOKMARKVIEW_H
+#define BOOKMARKVIEW_H
+
+#include <QListWidget>
+
+class BookmarkView {
+public:
+    BookmarkView(QListWidget* parent);
+    void add_bookmark(std::string file_path);
+private:
+    const int BOOKMARK_HEIGHT = 128;
+    QListWidget* view;
+};
+
+#endif // BOOKMARKVIEW_H

--- a/ViAn/GUI/bookmarkview.h
+++ b/ViAn/GUI/bookmarkview.h
@@ -12,7 +12,7 @@ private:
     QString get_input_text();
 
     const int BOOKMARK_HEIGHT = 64;
-    const int TEXT_EDIT_HEIGHT = 54;
+    const int TEXT_EDIT_HEIGHT = 32;
 
     QListWidget* view;
 };

--- a/ViAn/GUI/bookmarkview.h
+++ b/ViAn/GUI/bookmarkview.h
@@ -7,8 +7,13 @@ class BookmarkView {
 public:
     BookmarkView(QListWidget* parent);
     void add_bookmark(std::string file_path);
+    int get_num_bookmarks();
 private:
-    const int BOOKMARK_HEIGHT = 128;
+    QString get_input_text();
+
+    const int BOOKMARK_HEIGHT = 64;
+    const int TEXT_EDIT_HEIGHT = 54;
+
     QListWidget* view;
 };
 

--- a/ViAn/GUI/bookmarkview.h
+++ b/ViAn/GUI/bookmarkview.h
@@ -11,7 +11,7 @@ public:
 private:
     QString get_input_text();
 
-    const int BOOKMARK_HEIGHT = 64;
+    const int BOOKMARK_THUMBNAIL_HEIGHT = 64;
     const int TEXT_EDIT_MIN_HEIGHT = 32;
 
     QListWidget* view;

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -27,6 +27,9 @@ MainWindow::MainWindow(QWidget *parent) :
     iconOnButtonHandler = new IconOnButtonHandler();
     iconOnButtonHandler->set_pictures_to_buttons(ui);
 
+    // Setup a Bookmark View in the right sidebar in the GUI.
+    bookmark_view = new BookmarkView(ui->documentList);
+
     fileHandler = new FileHandler();
     set_shortcuts();
 
@@ -56,6 +59,7 @@ MainWindow::~MainWindow() {
     mvideo_player->terminate();
     delete mvideo_player;
     delete ui;
+    delete bookmark_view;
 }
 
 /**
@@ -279,9 +283,23 @@ void MainWindow::on_actionExit_triggered() {
 
 /**
  * @brief MainWindow::on_bookmarkButton_clicked
- * the button supposed to add a bookmark
+ * Button to add a bookmark to the bookmark view.
  */
 void MainWindow::on_bookmarkButton_clicked() {
+    QTreeWidgetItem *item;
+    MyQTreeWidgetItem *my_project;
+    if(ui->ProjectTree->selectedItems().size() == 1) {
+        item = ui->ProjectTree->selectedItems().first();
+        my_project = (MyQTreeWidgetItem*)get_project_from_object(item);
+        std::string proj_path = fileHandler->get_dir(my_project->id);
+        proj_path.append("/bookmarks");
+        ID dir_id = fileHandler->create_directory(proj_path);
+        std::string dir_path = fileHandler->get_dir(dir_id);
+        std::string file_path = mvideo_player->export_current_frame(dir_path);
+
+        bookmark_view->add_bookmark(file_path);
+        set_status_bar("Saved bookmark.");
+    }
 }
 
 /**

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -295,7 +295,9 @@ void MainWindow::on_bookmarkButton_clicked() {
         proj_path.append("/bookmarks");
         ID dir_id = fileHandler->create_directory(proj_path);
         std::string dir_path = fileHandler->get_dir(dir_id);
-        std::string file_path = mvideo_player->export_current_frame(dir_path);
+
+        std::string file_name = std::to_string(bookmark_view->get_num_bookmarks());
+        std::string file_path = mvideo_player->export_current_frame(dir_path, file_name);
 
         bookmark_view->add_bookmark(file_path);
         set_status_bar("Saved bookmark.");

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -289,13 +289,17 @@ void MainWindow::on_bookmarkButton_clicked() {
     QTreeWidgetItem *item;
     MyQTreeWidgetItem *my_project;
     if(ui->ProjectTree->selectedItems().size() == 1) {
+        // Get current project.
         item = ui->ProjectTree->selectedItems().first();
         my_project = (MyQTreeWidgetItem*)get_project_from_object(item);
         std::string proj_path = fileHandler->get_dir(my_project->id);
+        // Add bookmarks-folder to the project-folder.
         proj_path.append("/bookmarks");
         ID dir_id = fileHandler->create_directory(proj_path);
         std::string dir_path = fileHandler->get_dir(dir_id);
 
+        // Export the current frame in the bookmarks-folder.
+        // The names of the stored files will have increasing numbers.
         std::string file_name = std::to_string(bookmark_view->get_num_bookmarks());
         std::string file_path = mvideo_player->export_current_frame(dir_path, file_name);
 

--- a/ViAn/GUI/mainwindow.h
+++ b/ViAn/GUI/mainwindow.h
@@ -18,6 +18,7 @@
 #include "ui_mainwindow.h"
 #include "Filehandler/filehandler.h"
 #include "inputwindow.h"
+#include "bookmarkview.h"
 #include "action.h"
 #include "qtreeitems.h"
 #include <QMutex>
@@ -139,6 +140,7 @@ private:
     inputwindow *inputWindow;
     video_player* mvideo_player;
     IconOnButtonHandler *iconOnButtonHandler;
+    BookmarkView* bookmark_view;
 
     QSlider *video_slider;
 

--- a/ViAn/ViAn.pro
+++ b/ViAn/ViAn.pro
@@ -43,14 +43,16 @@ HEADERS += Library/customdialog.h
 SOURCES += GUI/mainwindow.cpp \
     GUI/icononbuttonhandler.cpp \
     GUI/inputwindow.cpp \
-    GUI/qtreeitems.cpp
+    GUI/qtreeitems.cpp \
+    GUI/bookmarkview.cpp
 
 
 HEADERS  += GUI/mainwindow.h \
     GUI/icononbuttonhandler.h \
     GUI/inputwindow.h \
     GUI/action.h \
-    GUI/qtreeitems.h
+    GUI/qtreeitems.h \
+    GUI/bookmarkview.h
 
 
 FORMS    += GUI/mainwindow.ui \

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -667,14 +667,14 @@ void video_player::scale_position(QPoint &pos) {
  * @param path_to_folder Path to the folder to store the file in.
  * @return The path to the stored image.
  */
-std::string video_player::export_current_frame(std::string path_to_folder) {
+std::string video_player::export_current_frame(std::string path_to_folder, std::string file_name) {
     convert_frame();
 
     QString path = QString::fromStdString(path_to_folder);
 
-    // Add "/FRAME_NR.tiff" to the path.
+    // Add "/file_name.tiff" to the path.
     path.append("/");
-    path.append(QString::number(get_current_frame_num()));
+    path.append(QString::fromStdString(file_name));
     path.append(".tiff");
 
     QImageWriter writer(path, "tiff");

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -101,9 +101,8 @@ void video_player::show_frame() {
 void video_player::convert_frame() {
     cv::Mat processed_frame;
 
-    // Process frame (draw overlay, zoom, scaling, contrast/brightness)
+    // Process frame (draw overlay, zoom, scaling, contrast/brightness, rotation)
     processed_frame = process_frame(frame);
-
 
     if (processed_frame.channels() == 3) {
         cv::Mat RGBframe;
@@ -665,18 +664,23 @@ void video_player::scale_position(QPoint &pos) {
  * @brief video_player::export_current_frame
  * Stores the current frame in the specified folder.
  * The stored frame will have the sam resolution as the video.
- * @param filename Path to the folder to store the file in.
+ * @param path_to_folder Path to the folder to store the file in.
+ * @return The path to the stored image.
  */
-void video_player::export_current_frame(QString path_to_folder) {
+std::string video_player::export_current_frame(std::string path_to_folder) {
     convert_frame();
 
-    // Add "/FRAME_NR.tiff" to the path.
-    path_to_folder.append("/");
-    path_to_folder.append(QString::number(get_current_frame_num()));
-    path_to_folder.append(".tiff");
+    QString path = QString::fromStdString(path_to_folder);
 
-    QImageWriter writer(path_to_folder, "tiff");
+    // Add "/FRAME_NR.tiff" to the path.
+    path.append("/");
+    path.append(QString::number(get_current_frame_num()));
+    path.append(".tiff");
+
+    QImageWriter writer(path, "tiff");
     writer.write(img);
+
+    return path.toStdString();
 }
 
 /**

--- a/ViAn/Video/video_player.h
+++ b/ViAn/Video/video_player.h
@@ -29,7 +29,7 @@ public:
     bool is_stopped();
     bool is_showing_overlay();
     bool is_showing_analysis_tool();
-    std::string export_current_frame(std::string path_to_folder);
+    std::string export_current_frame(std::string path_to_folder, std::string file_name);
     bool video_open();
 
     int get_num_frames();    

--- a/ViAn/Video/video_player.h
+++ b/ViAn/Video/video_player.h
@@ -29,7 +29,7 @@ public:
     bool is_stopped();
     bool is_showing_overlay();
     bool is_showing_analysis_tool();
-    void export_current_frame(QString path_to_folder);
+    std::string export_current_frame(std::string path_to_folder);
     bool video_open();
 
     int get_num_frames();    


### PR DESCRIPTION
A simple bookmark tool is implemented. The *-button now adds the current frame to the bookmark list to the right. It is represented with a thumbnail as well as a text description (entered by the user). The images used are exported by the video player and stored as tiff images in a bookmarks-folder in the project-folder.

Note that the bookmarks now have no effect. Nothing happens when selecting a bookmark in the list.