### PR TITLE
Added bookmark class, simple jump to frame, and no-scale export images

### DIFF
--- a/ViAn/GUI/bookmark.cpp
+++ b/ViAn/GUI/bookmark.cpp
@@ -2,6 +2,7 @@
 
 /**
  * @brief Bookmark::Bookmark
+ * @param frame_nbr Frame number associated with the bookmark.
  * @param img Thumbnail image.
  * @param string Text description of the bookmark.
  * @param view Parent widget of the bookmark.

--- a/ViAn/GUI/bookmark.cpp
+++ b/ViAn/GUI/bookmark.cpp
@@ -1,0 +1,20 @@
+#include "bookmark.h"
+
+/**
+ * @brief Bookmark::Bookmark
+ * @param img Thumbnail image.
+ * @param string Text description of the bookmark.
+ * @param view Parent widget of the bookmark.
+ */
+Bookmark::Bookmark(int frame_nbr, QImage img, QString string, QListWidget* view) : QListWidgetItem(string, view) {
+    frame_number = frame_nbr;
+    setData(Qt::DecorationRole, QPixmap::fromImage(img));
+}
+
+/**
+ * @brief Bookmark::get_frame_number
+ * @return Returns the frame number that the bookmark points to.
+ */
+int Bookmark::get_frame_number() {
+    return frame_number;
+}

--- a/ViAn/GUI/bookmark.h
+++ b/ViAn/GUI/bookmark.h
@@ -1,0 +1,14 @@
+#ifndef BOOKMARK_H
+#define BOOKMARK_H
+
+#include <QListWidgetItem>
+
+class Bookmark : public QListWidgetItem {
+public:
+    Bookmark(int frame_nbr, QImage img, QString string, QListWidget* view);
+    int get_frame_number();
+private:
+    int frame_number;
+};
+
+#endif // BOOKMARK_H

--- a/ViAn/GUI/bookmarkview.cpp
+++ b/ViAn/GUI/bookmarkview.cpp
@@ -23,6 +23,7 @@ int BookmarkView::get_num_bookmarks() {
  * @brief BookmarkView::add_bookmark
  * Adds a bookmark containing an image (thumbnail)
  * and a text description of the bookmark.
+ * @param frame_nbr Frame number associated with the bookmark.
  * @param file_path Path to the image of the bookmark.
  */
 void BookmarkView::add_bookmark(int frame_nbr, std::string file_path) {

--- a/ViAn/GUI/bookmarkview.cpp
+++ b/ViAn/GUI/bookmarkview.cpp
@@ -9,7 +9,6 @@
  */
 BookmarkView::BookmarkView(QListWidget* parent) {
     view = parent;
-    view->addItem("Bookmarks:");
 }
 
 /**
@@ -26,17 +25,15 @@ int BookmarkView::get_num_bookmarks() {
  * and a text description of the bookmark.
  * @param file_path Path to the image of the bookmark.
  */
-void BookmarkView::add_bookmark(std::string file_path) {
+void BookmarkView::add_bookmark(int frame_nbr, std::string file_path) {
     QImage img = QImage(QString::fromStdString(file_path), "TIFF");
     img = img.scaledToHeight(BOOKMARK_THUMBNAIL_HEIGHT);
 
     bool ok;
     QString bookmark_text = get_input_text(&ok);
     if (ok) {
-        QListWidgetItem *item = new QListWidgetItem(bookmark_text, view);
-        item->setData(Qt::DecorationRole, QPixmap::fromImage(img));
-
-        view->addItem(item);
+        Bookmark* bookmark = new Bookmark(frame_nbr, img, bookmark_text, view);
+        view->addItem(bookmark);
     }
 }
 

--- a/ViAn/GUI/bookmarkview.h
+++ b/ViAn/GUI/bookmarkview.h
@@ -1,12 +1,13 @@
 #ifndef BOOKMARKVIEW_H
 #define BOOKMARKVIEW_H
 
+#include "bookmark.h"
 #include <QListWidget>
 
 class BookmarkView {
 public:
     BookmarkView(QListWidget* parent);
-    void add_bookmark(std::string file_path);
+    void add_bookmark(int frame_nbr, std::string file_path);
     int get_num_bookmarks();
 private:
     QString get_input_text(bool* ok);

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -303,7 +303,7 @@ void MainWindow::on_bookmarkButton_clicked() {
         std::string file_name = std::to_string(bookmark_view->get_num_bookmarks());
         std::string file_path = mvideo_player->export_current_frame(dir_path, file_name);
 
-        bookmark_view->add_bookmark(file_path);
+        bookmark_view->add_bookmark(mvideo_player->get_current_frame_num(), file_path);
         set_status_bar("Saved bookmark.");
     }
 }
@@ -862,4 +862,14 @@ void MainWindow::on_actionContrast_Brightness_triggered() {
     }
     mvideo_player->set_contrast(contrast);
     mvideo_player->set_brightness(brightness);
+}
+
+/**
+ * @brief MainWindow::on_documentList_itemClicked
+ * Invoked when an item in the bookmark view has been clicked.
+ * @param item The bookmark that has been clicked.
+ */
+void MainWindow::on_documentList_itemClicked(QListWidgetItem *item) {
+    Bookmark* bookmark = (Bookmark*) item;
+    //mvideo_player->set_current_frame_num(bookmark->get_frame_number());
 }

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -879,5 +879,5 @@ void MainWindow::on_actionContrast_Brightness_triggered() {
  */
 void MainWindow::on_documentList_itemClicked(QListWidgetItem *item) {
     Bookmark* bookmark = (Bookmark*) item;
-    //mvideo_player->set_current_frame_num(bookmark->get_frame_number());
+    set_status_bar("Jump to frame " + to_string(bookmark->get_frame_number()));
 }

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -879,5 +879,8 @@ void MainWindow::on_actionContrast_Brightness_triggered() {
  */
 void MainWindow::on_documentList_itemClicked(QListWidgetItem *item) {
     Bookmark* bookmark = (Bookmark*) item;
-    set_status_bar("Jump to frame " + to_string(bookmark->get_frame_number()));
+    if (mvideo_player->is_paused()) {
+        mvideo_player->set_current_frame_num(bookmark->get_frame_number());
+        set_status_bar("Jump to frame: " + to_string(bookmark->get_frame_number()) + ".");
+    }
 }

--- a/ViAn/GUI/mainwindow.h
+++ b/ViAn/GUI/mainwindow.h
@@ -134,6 +134,8 @@ private slots:
 
     void on_actionContrast_Brightness_triggered();
 
+    void on_documentList_itemClicked(QListWidgetItem *item);
+
 private:
 
     Ui::MainWindow *ui;

--- a/ViAn/ViAn.pro
+++ b/ViAn/ViAn.pro
@@ -44,7 +44,8 @@ SOURCES += GUI/mainwindow.cpp \
     GUI/icononbuttonhandler.cpp \
     GUI/inputwindow.cpp \
     GUI/qtreeitems.cpp \
-    GUI/bookmarkview.cpp
+    GUI/bookmarkview.cpp \
+    GUI/bookmark.cpp
 
 
 HEADERS  += GUI/mainwindow.h \
@@ -52,7 +53,8 @@ HEADERS  += GUI/mainwindow.h \
     GUI/inputwindow.h \
     GUI/action.h \
     GUI/qtreeitems.h \
-    GUI/bookmarkview.h
+    GUI/bookmarkview.h \
+    GUI/bookmark.h
 
 
 FORMS    += GUI/mainwindow.ui \

--- a/ViAn/Video/video_player.h
+++ b/ViAn/Video/video_player.h
@@ -97,10 +97,10 @@ private:
     cv::Mat zoom_frame(cv::Mat &frame);
     cv::Mat contrast_frame(cv::Mat &frame);
     cv::Mat scale_frame(cv::Mat &src);
-    cv::Mat process_frame(cv::Mat &frame);
+    cv::Mat process_frame(cv::Mat &frame, bool scale);
     void update_overlay();
     void show_frame();
-    void convert_frame();
+    void convert_frame(bool scale);
     void scale_position(QPoint &pos);
 
     cv::VideoCapture capture;


### PR DESCRIPTION
*Pull request #100!*

A class ```Bookmark``` has been created (inheriting ```QListWidgetItem```) that holds the bookmark information. These ```Bookmark```s are added to the document list view. Clicking them invokes a method that jumps to the frame associated with the bookmark, though it **only works when the video is paused**, since the updated jump-to-frame functionality is still in the non-merged slider-branch.

Also fixed the export of frames, so that they are not scaled but stored as original size. (In the process I also cleaned up the code for scaling frames.)