### PR TITLE
Added option to invert the analysis area.

### DIFF
--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -862,4 +862,9 @@ void MainWindow::on_documentList_itemClicked(QListWidgetItem *item) {
  */
 void MainWindow::on_actionInvert_analysis_area_triggered() {
     mvideo_player->invert_analysis_area();
+    if (mvideo_player->is_including_area()) {
+        set_status_bar("Choose an area to run the analysis on.");
+    } else {
+        set_status_bar("Choose an area to exclude from the analysis.");
+    }
 }

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -855,3 +855,11 @@ void MainWindow::on_documentList_itemClicked(QListWidgetItem *item) {
         set_status_bar("Jump to frame: " + to_string(bookmark->get_frame_number()) + ".");
     }
 }
+
+/**
+ * @brief MainWindow::on_actionInvert_analysis_area_triggered
+ * Switches between choosing area for analysing and area for not analysing.
+ */
+void MainWindow::on_actionInvert_analysis_area_triggered() {
+    mvideo_player->invert_analysis_area();
+}

--- a/ViAn/GUI/mainwindow.h
+++ b/ViAn/GUI/mainwindow.h
@@ -136,6 +136,8 @@ private slots:
 
     void on_actionDelete_triggered();
 
+    void on_actionInvert_analysis_area_triggered();
+
 private:
 
     Ui::MainWindow *ui;

--- a/ViAn/GUI/mainwindow.ui
+++ b/ViAn/GUI/mainwindow.ui
@@ -321,7 +321,7 @@
      <x>0</x>
      <y>0</y>
      <width>616</width>
-     <height>20</height>
+     <height>19</height>
     </rect>
    </property>
    <property name="mouseTracking">
@@ -777,6 +777,9 @@
    </property>
   </action>
   <action name="actionInvert_analysis_area">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="text">
     <string>Invert analysis area</string>
    </property>

--- a/ViAn/GUI/mainwindow.ui
+++ b/ViAn/GUI/mainwindow.ui
@@ -371,6 +371,7 @@
     </property>
     <addaction name="actionShow_hide_overlay"/>
     <addaction name="actionShow_hide_analysis_area"/>
+    <addaction name="actionInvert_analysis_area"/>
     <addaction name="actionZoom_in"/>
     <addaction name="actionZoom_out"/>
     <addaction name="actionRotate_right"/>
@@ -473,6 +474,7 @@
    <addaction name="actionUndo"/>
    <addaction name="actionClear"/>
    <addaction name="actionShow_hide_analysis_area"/>
+   <addaction name="actionInvert_analysis_area"/>
   </widget>
   <action name="actionSave">
    <property name="icon">
@@ -724,6 +726,11 @@
   <action name="actionDelete">
    <property name="text">
     <string>Delete selected</string>
+   </property>
+  </action>
+  <action name="actionInvert_analysis_area">
+   <property name="text">
+    <string>Invert analysis area</string>
    </property>
   </action>
  </widget>

--- a/ViAn/Test/test_video_player.cpp
+++ b/ViAn/Test/test_video_player.cpp
@@ -336,9 +336,9 @@ void test_video_player::test_set_stop_video() {
  * @brief test_video_player::test_analys_area_toggle
  */
 void test_video_player::test_analys_area_toggle() {
-    bool original_value = mvideo->analysis_area->including_area();
+    bool original_value = mvideo->analysis_area->is_including_area();
     mvideo->analysis_area->invert_area();
-    QVERIFY(mvideo->analysis_area->including_area() != original_value);
+    QVERIFY(mvideo->analysis_area->is_including_area() != original_value);
 }
 
 /**

--- a/ViAn/Test/test_video_player.cpp
+++ b/ViAn/Test/test_video_player.cpp
@@ -333,18 +333,18 @@ void test_video_player::test_set_stop_video() {
 }
 
 /**
- * @brief test_video_player::test_analys_area_toggle
+ * @brief test_video_player::test_analysis_area_toggle
  */
-void test_video_player::test_analys_area_toggle() {
+void test_video_player::test_analysis_area_toggle() {
     bool original_value = mvideo->analysis_area->is_including_area();
     mvideo->analysis_area->invert_area();
     QVERIFY(mvideo->analysis_area->is_including_area() != original_value);
 }
 
 /**
- * @brief test_video_player::test_analys_area_points
+ * @brief test_video_player::test_analysis_area_points
  */
-void test_video_player::test_analys_area_points() {
+void test_video_player::test_analysis_area_points() {
     std::vector<QPoint> original_points;
     original_points.push_back(QPoint(0, 10));
     original_points.push_back(QPoint(210, 150));

--- a/ViAn/Test/test_video_player.cpp
+++ b/ViAn/Test/test_video_player.cpp
@@ -331,3 +331,30 @@ void test_video_player::test_set_stop_video() {
     QVERIFY(mvideo->get_current_frame_num() == 0);
     QVERIFY(mvideo->video_stopped);
 }
+
+/**
+ * @brief test_video_player::test_analys_area_toggle
+ */
+void test_video_player::test_analys_area_toggle() {
+    bool original_value = mvideo->analysis_area->including_area();
+    mvideo->analysis_area->invert_area();
+    QVERIFY(mvideo->analysis_area->including_area() != original_value);
+}
+
+/**
+ * @brief test_video_player::test_analys_area_points
+ */
+void test_video_player::test_analys_area_points() {
+    std::vector<QPoint> original_points;
+    original_points.push_back(QPoint(0, 10));
+    original_points.push_back(QPoint(210, 150));
+    original_points.push_back(QPoint(255, 255));
+    original_points.push_back(QPoint(1024, 0));
+    for (std::vector<int>::size_type i = 0; i != original_points.size(); i++) {
+        mvideo->analysis_area->add_point(original_points[i]);
+    }
+    std::vector<cv::Point>* points = mvideo->analysis_area->get_polygon();
+    for (std::vector<int>::size_type i = 0; i != points->size(); i++) {
+        QVERIFY((*points)[i].x == original_points[i].x());
+    }
+}

--- a/ViAn/Test/test_video_player.h
+++ b/ViAn/Test/test_video_player.h
@@ -39,6 +39,8 @@ private slots:
     void test_set_play_video();
     void test_set_pause_video();
     void test_set_stop_video();
+    void test_analys_area_toggle();
+    void test_analys_area_points();
 
 private:
     video_player* mvideo;

--- a/ViAn/Test/test_video_player.h
+++ b/ViAn/Test/test_video_player.h
@@ -39,8 +39,8 @@ private slots:
     void test_set_play_video();
     void test_set_pause_video();
     void test_set_stop_video();
-    void test_analys_area_toggle();
-    void test_analys_area_points();
+    void test_analysis_area_toggle();
+    void test_analysis_area_points();
 
 private:
     video_player* mvideo;

--- a/ViAn/Video/shapes/analysarea.cpp
+++ b/ViAn/Video/shapes/analysarea.cpp
@@ -32,7 +32,7 @@ cv::Mat AnalysArea::draw(cv::Mat &frame) {
         const cv::Point* ppt[1] = {rook_points[0]};
         int npt[] = {size};
 
-        if (inverted) {
+        if (include_area_to_analyse) {
             // Frame with white polygon, otherwise zeros.
             cv::Mat inside_area;
             inside_area = frame.zeros(frame.rows, frame.cols, frame.type());
@@ -91,7 +91,24 @@ void AnalysArea::add_point(QPoint pos) {
  * Inverts the area being drawn.
  */
 void AnalysArea::invert_area() {
-    inverted = !inverted;
+    include_area_to_analyse = !include_area_to_analyse;
+}
+
+/**
+ * @brief AnalysArea::including_area
+ * @return Returns true if the area should be included in the
+ *         analysis, false if it should be excluded.
+ */
+bool AnalysArea::including_area() {
+    return include_area_to_analyse;
+}
+
+/**
+ * @brief AnalysArea::get_polygon
+ * @return Returns pointer to the choosen polygon.
+ */
+std::vector<cv::Point>* AnalysArea::get_polygon() {
+    return points;
 }
 
 /**

--- a/ViAn/Video/shapes/analysarea.cpp
+++ b/ViAn/Video/shapes/analysarea.cpp
@@ -73,6 +73,10 @@ cv::Mat AnalysArea::draw(cv::Mat &frame) {
         }
         // Draw contour of the polygon.
         cv::polylines(frame, ppt, npt, 1, true, cv::Scalar(255, 0, 0), Shape::LINE_THICKNESS);
+
+        // Draw a circle indicating the last choosen point.
+        int RADIUS = 8;
+        cv::circle(frame, points->back(), RADIUS, cv::Scalar(0, 255, 255), Shape::LINE_THICKNESS);
     }
     return frame;
 }

--- a/ViAn/Video/shapes/analysarea.cpp
+++ b/ViAn/Video/shapes/analysarea.cpp
@@ -47,13 +47,13 @@ cv::Mat AnalysArea::draw(cv::Mat &frame) {
             white_frame = cv::Scalar(255,255,255);
 
             // Original frame with opacity.
-            cv::Mat opacityframe;
-            cv::addWeighted(white_frame, Shape::ALPHA, frame, 1.0 - Shape::ALPHA, 0.0, opacityframe);
+            cv::Mat opacity_frame;
+            cv::addWeighted(white_frame, Shape::ALPHA, frame, 1.0 - Shape::ALPHA, 0.0, opacity_frame);
 
             cv::Mat original_cut, opacity_cut;
 
             // Cut out the polygon from the frame with opacity.
-            cv::bitwise_and(outside_area, opacityframe, opacity_cut);
+            cv::bitwise_and(outside_area, opacity_frame, opacity_cut);
 
             // Cut out everything but the polygon from the original frame.
             cv::bitwise_and(inside_area, frame, original_cut);

--- a/ViAn/Video/shapes/analysarea.cpp
+++ b/ViAn/Video/shapes/analysarea.cpp
@@ -99,7 +99,7 @@ void AnalysArea::invert_area() {
  * @return Returns true if the area should be included in the
  *         analysis, false if it should be excluded.
  */
-bool AnalysArea::including_area() {
+bool AnalysArea::is_including_area() {
     return include_area_to_analyse;
 }
 

--- a/ViAn/Video/shapes/analysarea.h
+++ b/ViAn/Video/shapes/analysarea.h
@@ -11,11 +11,15 @@ public:
     cv::Mat draw(cv::Mat &frame);
     void add_point(QPoint pos);
     void invert_area();
+    bool including_area();
+    std::vector<cv::Point>* get_polygon();
     void undo();
     void clear();
 private:
     std::vector<cv::Point>* points = new std::vector<cv::Point>();
-    bool inverted = false;
+    // Bool indicating if an area for analysis or an area for
+    // not running analysis is being choosen.
+    bool include_area_to_analyse = true;
 };
 
 #endif // ANALYSAREA_H

--- a/ViAn/Video/shapes/analysarea.h
+++ b/ViAn/Video/shapes/analysarea.h
@@ -11,7 +11,7 @@ public:
     cv::Mat draw(cv::Mat &frame);
     void add_point(QPoint pos);
     void invert_area();
-    bool including_area();
+    bool is_including_area();
     std::vector<cv::Point>* get_polygon();
     void undo();
     void clear();

--- a/ViAn/Video/shapes/analysarea.h
+++ b/ViAn/Video/shapes/analysarea.h
@@ -10,10 +10,12 @@ public:
     ~AnalysArea();
     cv::Mat draw(cv::Mat &frame);
     void add_point(QPoint pos);
+    void invert_area();
     void undo();
     void clear();
 private:
     std::vector<cv::Point>* points = new std::vector<cv::Point>();
+    bool inverted = false;
 };
 
 #endif // ANALYSAREA_H

--- a/ViAn/Video/shapes/shape.h
+++ b/ViAn/Video/shapes/shape.h
@@ -20,7 +20,8 @@ public:
     static cv::Scalar qcolor_to_scalar(QColor col);
     static cv::Point qpoint_to_point(QPoint pnt);
 
-    static const int LINE_THICKNESS = 2;
+    static const int LINE_THICKNESS = 2; // Constant used for the thickness of the drawn shapes.
+    static constexpr double ALPHA = 0.6; // Costant used for the opacity.
 
 protected:
     cv::Scalar colour;

--- a/ViAn/Video/shapes/zoomrectangle.cpp
+++ b/ViAn/Video/shapes/zoomrectangle.cpp
@@ -142,8 +142,7 @@ cv::Mat ZoomRectangle::draw(cv::Mat &frame) {
     cv::Mat area = frame(rect);
     // CV_8UC3 means 8-bit unsigned 3-channel array.
     cv::Mat coloured_area(area.size(), CV_8UC3, cv::Scalar(125, 125, 125));
-    double alpha = 0.6;
-    cv::addWeighted(coloured_area, alpha, area, 1.0 - alpha , 0.0, area);
+    cv::addWeighted(coloured_area, ALPHA, area, 1.0 - ALPHA , 0.0, area);
     cv::rectangle(frame, rect, colour, LINE_THICKNESS);
     return frame;
 }

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -576,10 +576,10 @@ void video_player::undo_overlay() {
  * and the video is loaded and paused.
  */
 void video_player::clear_overlay() {
-    if (capture.isOpened() && is_paused()) {
+    if (capture.isOpened()) {
         if (choosing_analysis_area) {
             analysis_area->clear();
-        } else {
+        } else if (is_paused()) {
             video_overlay->clear(get_current_frame_num());
         }
         update_overlay();
@@ -592,10 +592,6 @@ void video_player::clear_overlay() {
  */
 void video_player::toggle_analysis_area() {
     choosing_analysis_area = !choosing_analysis_area;
-    // Reset the area selection to including an area.
-    if (!is_including_area()) {
-        analysis_area->invert_area();
-    }
     update_overlay();
 }
 

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -538,6 +538,15 @@ void video_player::toggle_analysis_area() {
 }
 
 /**
+ * @brief video_player::invert_analysis_area
+ * Switches between choosing area for analysing and area for not analysing.
+ */
+void video_player::invert_analysis_area() {
+    analysis_area->invert_area();
+    update_overlay();
+}
+
+/**
  * @brief video_player::zoom_in
  * Sets a state in the video overlay
  * for the user to choose an area,

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -147,7 +147,6 @@ void video_player::convert_frame(bool scale) {
  * @return Returns the processed frame.
  */
 cv::Mat video_player::process_frame(cv::Mat &src, bool scale) {
-    bool copy_to = false;
     // Copy the frame, so that we don't alter the original frame (which will be reused next draw loop).
     cv::Mat processed_frame = src.clone();
     processed_frame = video_overlay->draw_overlay(processed_frame, get_current_frame_num());

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -560,10 +560,10 @@ void video_player::set_overlay_colour(QColor colour) {
  * and the video is loaded and paused.
  */
 void video_player::undo_overlay() {
-    if (capture.isOpened() && is_paused()) {
+    if (capture.isOpened()) {
         if (choosing_analysis_area) {
             analysis_area->undo();
-        } else {
+        } else if (is_paused()) {
             video_overlay->undo(get_current_frame_num());
         }
         update_overlay();

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -534,6 +534,10 @@ void video_player::clear_overlay() {
  */
 void video_player::toggle_analysis_area() {
     choosing_analysis_area = !choosing_analysis_area;
+    // Reset the area selection to including an area.
+    if (!is_including_area()) {
+        analysis_area->invert_area();
+    }
     update_overlay();
 }
 
@@ -544,6 +548,15 @@ void video_player::toggle_analysis_area() {
 void video_player::invert_analysis_area() {
     analysis_area->invert_area();
     update_overlay();
+}
+
+/**
+ * @brief video_player::is_including_area
+ * @return Returns true if the area should be included in the
+ *         analysis, false if it should be excluded.
+ */
+bool video_player::is_including_area() {
+    return analysis_area->is_including_area();
 }
 
 /**
@@ -688,8 +701,8 @@ void video_player::scale_position(QPoint &pos) {
     // on the QLabel where the frame is shown. The frame is
     // centered vertically, so the empty part of the QLabel
     // at the top needs to be subtracted.
-    int rotated_x;
-    int rotated_y;
+    int rotated_x = 0;
+    int rotated_y = 0;
     if (rotate_direction == ROTATE_90) {
         rotated_x = (pos.y() - (double) (qlabel_height - frame_width) / 2);
         rotated_y = frame_height - pos.x();

--- a/ViAn/Video/video_player.h
+++ b/ViAn/Video/video_player.h
@@ -55,6 +55,7 @@ public:
     void undo_overlay();
     void clear_overlay();
     void toggle_analysis_area();
+    void invert_analysis_area();
     void zoom_in();
     void zoom_out();
     void rotate_right();

--- a/ViAn/Video/video_player.h
+++ b/ViAn/Video/video_player.h
@@ -56,6 +56,7 @@ public:
     void clear_overlay();
     void toggle_analysis_area();
     void invert_analysis_area();
+    bool is_including_area();
     void zoom_in();
     void zoom_out();
     void rotate_right();


### PR DESCRIPTION
Added the option to choose an area to include or wxclude in the analysis. Changed the representation so that the area to exclude from analysis is marked grey, and the area to include is unmarked.

Also added tests, extracted opacity to a constant, and fixed a possibly uninitialised warning.