### PR TITLE
Separated Bookmark and BookmarkItem

### DIFF
--- a/ViAn/GUI/bookmark.cpp
+++ b/ViAn/GUI/bookmark.cpp
@@ -3,13 +3,13 @@
 /**
  * @brief Bookmark::Bookmark
  * @param frame_nbr Frame number associated with the bookmark.
- * @param img Thumbnail image.
+ * @param file_pth Path to the stored image.
  * @param string Text description of the bookmark.
- * @param view Parent widget of the bookmark.
  */
-Bookmark::Bookmark(int frame_nbr, QImage img, QString string, QListWidget* view) : QListWidgetItem(string, view) {
+Bookmark::Bookmark(int frame_nbr, std::string file_pth, QString string) {
     frame_number = frame_nbr;
-    setData(Qt::DecorationRole, QPixmap::fromImage(img));
+    file_path = file_pth;
+    description = string;
 }
 
 /**
@@ -18,4 +18,20 @@ Bookmark::Bookmark(int frame_nbr, QImage img, QString string, QListWidget* view)
  */
 int Bookmark::get_frame_number() {
     return frame_number;
+}
+
+/**
+ * @brief Bookmark::get_file_path
+ * @return Returns the file path to the stored image associated with the bookmark.
+ */
+std::string Bookmark::get_file_path() {
+    return file_path;
+}
+
+/**
+ * @brief Bookmark::get_description
+ * @return Returns the description associated with the bookmark.
+ */
+QString Bookmark::get_description() {
+    return description;
 }

--- a/ViAn/GUI/bookmark.h
+++ b/ViAn/GUI/bookmark.h
@@ -1,14 +1,19 @@
 #ifndef BOOKMARK_H
 #define BOOKMARK_H
 
-#include <QListWidgetItem>
+#include <QString>
+#include <string>
 
-class Bookmark : public QListWidgetItem {
+class Bookmark {
 public:
-    Bookmark(int frame_nbr, QImage img, QString string, QListWidget* view);
+    Bookmark(int frame_nbr, std::string file_pth, QString string);
     int get_frame_number();
+    std::string get_file_path();
+    QString get_description();
 private:
     int frame_number;
+    std::string file_path;
+    QString description;
 };
 
 #endif // BOOKMARK_H

--- a/ViAn/GUI/bookmarkitem.cpp
+++ b/ViAn/GUI/bookmarkitem.cpp
@@ -3,7 +3,7 @@
 /**
  * @brief BookmarkItem::BookmarkItem
  * @param frame_nbr Frame number associated with the bookmark.
- * @param img Thumbnail image.
+ * @param file_path Path to the stored image.
  * @param string Text description of the bookmark.
  * @param view Parent widget of the bookmark.
  */
@@ -14,6 +14,10 @@ BookmarkItem::BookmarkItem(int frame_nbr, std::string file_path, QString string,
     setData(Qt::DecorationRole, QPixmap::fromImage(img));
 }
 
+/**
+ * @brief BookmarkItem::get_bookmark
+ * @return Returns the bookmark representation.
+ */
 Bookmark* BookmarkItem::get_bookmark() {
     return bookmark;
 }

--- a/ViAn/GUI/bookmarkitem.cpp
+++ b/ViAn/GUI/bookmarkitem.cpp
@@ -9,9 +9,7 @@
  */
 BookmarkItem::BookmarkItem(int frame_nbr, std::string file_path, QString string, QListWidget* view) : QListWidgetItem(string, view) {
     bookmark = new Bookmark(frame_nbr, file_path, string);
-    QImage img = QImage(QString::fromStdString(file_path), "TIFF");
-    img = img.scaledToHeight(BOOKMARK_THUMBNAIL_HEIGHT);
-    setData(Qt::DecorationRole, QPixmap::fromImage(img));
+    create_thumbnail(file_path);
 }
 
 /**
@@ -21,7 +19,16 @@ BookmarkItem::BookmarkItem(int frame_nbr, std::string file_path, QString string,
  */
 BookmarkItem::BookmarkItem(Bookmark bookmrk, QListWidget* view) : QListWidgetItem(bookmrk.get_description(), view) {
     bookmark = &bookmrk;
-    QImage img = QImage(QString::fromStdString(bookmrk.get_file_path()), "TIFF");
+    create_thumbnail(bookmrk.get_file_path());
+}
+
+/**
+ * @brief BookmarkItem::create_thumbnail
+ * Creates and adds a thumbnail.
+ * @param file_path Path to the stored image.
+ */
+void BookmarkItem::create_thumbnail(std::string file_path) {
+    QImage img = QImage(QString::fromStdString(file_path), "TIFF");
     img = img.scaledToHeight(BOOKMARK_THUMBNAIL_HEIGHT);
     setData(Qt::DecorationRole, QPixmap::fromImage(img));
 }

--- a/ViAn/GUI/bookmarkitem.cpp
+++ b/ViAn/GUI/bookmarkitem.cpp
@@ -15,6 +15,18 @@ BookmarkItem::BookmarkItem(int frame_nbr, std::string file_path, QString string,
 }
 
 /**
+ * @brief BookmarkItem::BookmarkItem
+ * @param bookmrk Bookmark containing relevant.
+ * @param view Parent widget of the bookmark.
+ */
+BookmarkItem::BookmarkItem(Bookmark bookmrk, QListWidget* view) : QListWidgetItem(bookmrk.get_description(), view) {
+    bookmark = &bookmrk;
+    QImage img = QImage(QString::fromStdString(bookmrk.get_file_path()), "TIFF");
+    img = img.scaledToHeight(BOOKMARK_THUMBNAIL_HEIGHT);
+    setData(Qt::DecorationRole, QPixmap::fromImage(img));
+}
+
+/**
  * @brief BookmarkItem::get_bookmark
  * @return Returns the bookmark representation.
  */

--- a/ViAn/GUI/bookmarkitem.cpp
+++ b/ViAn/GUI/bookmarkitem.cpp
@@ -1,0 +1,27 @@
+#include "bookmarkitem.h"
+
+/**
+ * @brief BookmarkItem::BookmarkItem
+ * @param frame_nbr Frame number associated with the bookmark.
+ * @param img Thumbnail image.
+ * @param string Text description of the bookmark.
+ * @param view Parent widget of the bookmark.
+ */
+BookmarkItem::BookmarkItem(int frame_nbr, std::string file_path, QString string, QListWidget* view) : QListWidgetItem(string, view) {
+    bookmark = new Bookmark(frame_nbr, file_path, string);
+    QImage img = QImage(QString::fromStdString(file_path), "TIFF");
+    img = img.scaledToHeight(BOOKMARK_THUMBNAIL_HEIGHT);
+    setData(Qt::DecorationRole, QPixmap::fromImage(img));
+}
+
+Bookmark* BookmarkItem::get_bookmark() {
+    return bookmark;
+}
+
+/**
+ * @brief BookmarkItem::get_frame_number
+ * @return Returns the frame number that the bookmark points to.
+ */
+int BookmarkItem::get_frame_number() {
+    return bookmark->get_frame_number();
+}

--- a/ViAn/GUI/bookmarkitem.h
+++ b/ViAn/GUI/bookmarkitem.h
@@ -11,6 +11,7 @@ public:
     Bookmark* get_bookmark();
     int get_frame_number();
 private:
+    void create_thumbnail(std::string file_path);
     const int BOOKMARK_THUMBNAIL_HEIGHT = 64;
     Bookmark* bookmark;
 };

--- a/ViAn/GUI/bookmarkitem.h
+++ b/ViAn/GUI/bookmarkitem.h
@@ -1,0 +1,17 @@
+#ifndef BOOKMARKITEM_H
+#define BOOKMARKITEM_H
+
+#include "bookmark.h"
+#include <QListWidgetItem>
+
+class BookmarkItem : public QListWidgetItem {
+public:
+    BookmarkItem(int frame_nbr, std::string file_path, QString string, QListWidget* view);
+    Bookmark* get_bookmark();
+    int get_frame_number();
+private:
+    const int BOOKMARK_THUMBNAIL_HEIGHT = 64;
+    Bookmark* bookmark;
+};
+
+#endif // BOOKMARKITEM_H

--- a/ViAn/GUI/bookmarkitem.h
+++ b/ViAn/GUI/bookmarkitem.h
@@ -7,6 +7,7 @@
 class BookmarkItem : public QListWidgetItem {
 public:
     BookmarkItem(int frame_nbr, std::string file_path, QString string, QListWidget* view);
+    BookmarkItem(Bookmark bookmrk, QListWidget* view);
     Bookmark* get_bookmark();
     int get_frame_number();
 private:

--- a/ViAn/GUI/bookmarkview.cpp
+++ b/ViAn/GUI/bookmarkview.cpp
@@ -27,13 +27,10 @@ int BookmarkView::get_num_bookmarks() {
  * @param file_path Path to the image of the bookmark.
  */
 void BookmarkView::add_bookmark(int frame_nbr, std::string file_path) {
-    QImage img = QImage(QString::fromStdString(file_path), "TIFF");
-    img = img.scaledToHeight(BOOKMARK_THUMBNAIL_HEIGHT);
-
     bool ok;
     QString bookmark_text = get_input_text(&ok);
     if (ok) {
-        Bookmark* bookmark = new Bookmark(frame_nbr, img, bookmark_text, view);
+        BookmarkItem* bookmark = new BookmarkItem(frame_nbr, file_path, bookmark_text, view);
         view->addItem(bookmark);
     }
 }

--- a/ViAn/GUI/bookmarkview.cpp
+++ b/ViAn/GUI/bookmarkview.cpp
@@ -30,9 +30,19 @@ void BookmarkView::add_bookmark(int frame_nbr, std::string file_path) {
     bool ok;
     QString bookmark_text = get_input_text(&ok);
     if (ok) {
-        BookmarkItem* bookmark = new BookmarkItem(frame_nbr, file_path, bookmark_text, view);
-        view->addItem(bookmark);
+        BookmarkItem* bookmark_item = new BookmarkItem(frame_nbr, file_path, bookmark_text, view);
+        view->addItem(bookmark_item);
     }
+}
+
+/**
+ * @brief BookmarkView::add_bookmark
+ * Adds a bookmark to the bookmark view.
+ * @param bookmark Bookmark to add.
+ */
+void BookmarkView::add_bookmark(Bookmark bookmark) {
+    BookmarkItem* bookmark_item = new BookmarkItem(bookmark, view);
+    view->addItem(bookmark_item);
 }
 
 /**

--- a/ViAn/GUI/bookmarkview.h
+++ b/ViAn/GUI/bookmarkview.h
@@ -8,6 +8,7 @@ class BookmarkView {
 public:
     BookmarkView(QListWidget* parent);
     void add_bookmark(int frame_nbr, std::string file_path);
+    void add_bookmark(Bookmark bookmark);
     int get_num_bookmarks();
 private:
     QString get_input_text(bool* ok);

--- a/ViAn/GUI/bookmarkview.h
+++ b/ViAn/GUI/bookmarkview.h
@@ -1,7 +1,7 @@
 #ifndef BOOKMARKVIEW_H
 #define BOOKMARKVIEW_H
 
-#include "bookmark.h"
+#include "bookmarkitem.h"
 #include <QListWidget>
 
 class BookmarkView {
@@ -12,7 +12,6 @@ public:
 private:
     QString get_input_text(bool* ok);
 
-    const int BOOKMARK_THUMBNAIL_HEIGHT = 64;
     const int TEXT_EDIT_MIN_HEIGHT = 32;
 
     QListWidget* view;

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -936,7 +936,7 @@ void MainWindow::on_actionRotate_left_triggered() {
  * @param item The bookmark that has been clicked.
  */
 void MainWindow::on_documentList_itemClicked(QListWidgetItem *item) {
-    Bookmark* bookmark = (Bookmark*) item;
+    BookmarkItem* bookmark = (BookmarkItem*) item;
     emit set_playback_frame(bookmark->get_frame_number());
     set_status_bar("Jump to frame: " + to_string(bookmark->get_frame_number()) + ".");
 

--- a/ViAn/ViAn.pro
+++ b/ViAn/ViAn.pro
@@ -45,6 +45,7 @@ SOURCES += GUI/mainwindow.cpp \
     GUI/inputwindow.cpp \
     GUI/qtreeitems.cpp \
     GUI/bookmarkview.cpp \
+    GUI/bookmarkitem.cpp \
     GUI/bookmark.cpp
 
 
@@ -54,6 +55,7 @@ HEADERS  += GUI/mainwindow.h \
     GUI/action.h \
     GUI/qtreeitems.h \
     GUI/bookmarkview.h \
+    GUI/bookmarkitem.h \
     GUI/bookmark.h
 
 


### PR DESCRIPTION
Changed the bookmark representation to make it easier to store bookmarks. There's a class `BookmarkItem` and objects of this class is added to the QListWidget holding the bookmarks. Within the `BookmarkItem` is a pointer to a `Bookmark`-object holding the information that can be stored.