### PR TITLE
Analysis overlay

### DIFF
--- a/ViAn/GUI/bookmarkitem.cpp
+++ b/ViAn/GUI/bookmarkitem.cpp
@@ -30,7 +30,6 @@ BookmarkItem::BookmarkItem(Bookmark* bookmrk, QListWidget* view) : QListWidgetIt
  */
 void BookmarkItem::create_thumbnail(QString file_path) {
     QImage img = QImage(file_path, "TIFF");
-
     img = img.scaledToHeight(BOOKMARK_THUMBNAIL_HEIGHT);
     setData(Qt::DecorationRole, QPixmap::fromImage(img));
 }

--- a/ViAn/GUI/bookmarkitem.cpp
+++ b/ViAn/GUI/bookmarkitem.cpp
@@ -30,6 +30,7 @@ BookmarkItem::BookmarkItem(Bookmark* bookmrk, QListWidget* view) : QListWidgetIt
  */
 void BookmarkItem::create_thumbnail(QString file_path) {
     QImage img = QImage(file_path, "TIFF");
+
     img = img.scaledToHeight(BOOKMARK_THUMBNAIL_HEIGHT);
     setData(Qt::DecorationRole, QPixmap::fromImage(img));
 }

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -999,3 +999,15 @@ void MainWindow::on_actionInvert_analysis_area_triggered() {
     }
 }
 
+/**
+ * @brief MainWindow::on_actionShow_hide_analysis_overlay_triggered
+ * Toggles the state of showing the analysis overlay.
+ */
+void MainWindow::on_actionShow_hide_analysis_overlay_triggered() {
+    mvideo_player->toggle_analysis_overlay();
+    if (mvideo_player->is_showing_analysis_overlay()) {
+        set_status_bar("Showing analysis overlay: on.");
+    } else {
+        set_status_bar("Showing analysis overlay: off.");
+    }
+}

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -402,11 +402,11 @@ void MainWindow::on_project_tree_itemDoubleClicked(QTreeWidgetItem *item, int co
     }
 }
 
- /** @brief MainWindow::on_actionShow_hide_overlay_triggered
+ /** @brief MainWindow::on_action_show_hide_overlay_triggered
  * Toggles the showing/hiding of the overlay.
  * Invoked by menu item.
  */
-void MainWindow::on_actionShow_hide_overlay_triggered() {
+void MainWindow::on_action_show_hide_overlay_triggered() {
     mvideo_player->toggle_overlay();
     toggle_toolbar();
     if (mvideo_player->is_showing_overlay()) {
@@ -803,18 +803,18 @@ void MainWindow::toggle_toolbar() {
         ui->toolBar_analysis->show();
         ui->toolBar->hide();
         ui->toolBar_overlay->hide();
-        ui->actionShow_hide_overlay->setEnabled(false);
+        ui->action_show_hide_overlay->setEnabled(false);
     } else if (mvideo_player->is_showing_overlay()) {
         ui->toolBar_analysis->hide();
         ui->toolBar->hide();
         ui->toolBar_overlay->show();
-        ui->actionShow_hide_analysis_area->setEnabled(false);
+        ui->action_show_hide_analysis_area->setEnabled(false);
     } else {
         ui->toolBar_analysis->hide();
         ui->toolBar->show();
         ui->toolBar_overlay->hide();
-        ui->actionShow_hide_overlay->setEnabled(true);
-        ui->actionShow_hide_analysis_area->setEnabled(true);
+        ui->action_show_hide_overlay->setEnabled(true);
+        ui->action_show_hide_analysis_area->setEnabled(true);
     }
 }
 
@@ -857,10 +857,10 @@ void MainWindow::on_video_slider_sliderPressed() {
     }
 }
 
-/** @brief MainWindow::on_actionShow_hide_analysis_area_triggered
+/** @brief MainWindow::on_action_show_hide_analysis_area_triggered
  * Toggles the choosing of an analysis area.
  */
-void MainWindow::on_actionShow_hide_analysis_area_triggered() {
+void MainWindow::on_action_show_hide_analysis_area_triggered() {
     mvideo_player->toggle_analysis_area();
     toggle_toolbar();
     if (mvideo_player->is_showing_analysis_tool()) {
@@ -1000,10 +1000,10 @@ void MainWindow::on_actionInvert_analysis_area_triggered() {
 }
 
 /**
- * @brief MainWindow::on_actionShow_hide_analysis_overlay_triggered
+ * @brief MainWindow::on_action_show_hide_analysis_overlay_triggered
  * Toggles the state of showing the analysis overlay.
  */
-void MainWindow::on_actionShow_hide_analysis_overlay_triggered() {
+void MainWindow::on_action_show_hide_analysis_overlay_triggered() {
     mvideo_player->toggle_analysis_overlay();
     if (mvideo_player->is_showing_analysis_overlay()) {
         set_status_bar("Showing analysis overlay: on.");

--- a/ViAn/GUI/mainwindow.h
+++ b/ViAn/GUI/mainwindow.h
@@ -148,6 +148,8 @@ private slots:
 
     void on_actionInvert_analysis_area_triggered();
 
+    void on_actionShow_hide_analysis_overlay_triggered();
+
 private:
 
     Ui::MainWindow *ui;

--- a/ViAn/GUI/mainwindow.h
+++ b/ViAn/GUI/mainwindow.h
@@ -92,7 +92,7 @@ private slots:
 
     void on_actionAddProject_triggered();
     
-    void on_actionShow_hide_overlay_triggered();
+    void on_action_show_hide_overlay_triggered();
 
     void on_actionColour_triggered();
 
@@ -130,7 +130,7 @@ private slots:
 
     void on_project_tree_itemDoubleClicked(QTreeWidgetItem *item, int column);
     
-    void on_actionShow_hide_analysis_area_triggered();
+    void on_action_show_hide_analysis_area_triggered();
 
     void on_actionContrast_Brightness_triggered();
 
@@ -148,7 +148,7 @@ private slots:
 
     void on_actionInvert_analysis_area_triggered();
 
-    void on_actionShow_hide_analysis_overlay_triggered();
+    void on_action_show_hide_analysis_overlay_triggered();
 
 private:
 

--- a/ViAn/GUI/mainwindow.ui
+++ b/ViAn/GUI/mainwindow.ui
@@ -73,7 +73,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>232</width>
-                <height>283</height>
+                <height>282</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_2">

--- a/ViAn/GUI/mainwindow.ui
+++ b/ViAn/GUI/mainwindow.ui
@@ -73,7 +73,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>232</width>
-                <height>282</height>
+                <height>283</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_2">
@@ -401,6 +401,7 @@
      <string>View</string>
     </property>
     <addaction name="actionShow_hide_overlay"/>
+    <addaction name="actionShow_hide_analysis_overlay"/>
     <addaction name="actionShow_hide_analysis_area"/>
     <addaction name="actionInvert_analysis_area"/>
     <addaction name="actionZoom_in"/>
@@ -466,6 +467,7 @@
    <addaction name="actionRotate_left"/>
    <addaction name="actionShow_hide_overlay"/>
    <addaction name="actionShow_hide_analysis_area"/>
+   <addaction name="actionShow_hide_analysis_overlay"/>
   </widget>
   <widget class="QToolBar" name="toolBar_overlay">
    <property name="enabled">
@@ -858,6 +860,17 @@
    </property>
    <property name="text">
     <string>Invert analysis area</string>
+   </property>
+  </action>
+  <action name="actionShow_hide_analysis_overlay">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show/hide analysis overlay</string>
    </property>
   </action>
  </widget>

--- a/ViAn/GUI/mainwindow.ui
+++ b/ViAn/GUI/mainwindow.ui
@@ -73,7 +73,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>232</width>
-                <height>282</height>
+                <height>283</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_2">
@@ -400,9 +400,9 @@
     <property name="title">
      <string>View</string>
     </property>
-    <addaction name="actionShow_hide_overlay"/>
-    <addaction name="actionShow_hide_analysis_overlay"/>
-    <addaction name="actionShow_hide_analysis_area"/>
+    <addaction name="action_show_hide_overlay"/>
+    <addaction name="action_show_hide_analysis_overlay"/>
+    <addaction name="action_show_hide_analysis_area"/>
     <addaction name="actionInvert_analysis_area"/>
     <addaction name="actionZoom_in"/>
     <addaction name="actionZoom_out"/>
@@ -465,9 +465,9 @@
    <addaction name="actionZoom_out"/>
    <addaction name="actionRotate_right"/>
    <addaction name="actionRotate_left"/>
-   <addaction name="actionShow_hide_overlay"/>
-   <addaction name="actionShow_hide_analysis_area"/>
-   <addaction name="actionShow_hide_analysis_overlay"/>
+   <addaction name="action_show_hide_overlay"/>
+   <addaction name="action_show_hide_analysis_area"/>
+   <addaction name="action_show_hide_analysis_overlay"/>
   </widget>
   <widget class="QToolBar" name="toolBar_overlay">
    <property name="enabled">
@@ -491,7 +491,7 @@
    <addaction name="actionPen"/>
    <addaction name="actionUndo"/>
    <addaction name="actionClear"/>
-   <addaction name="actionShow_hide_overlay"/>
+   <addaction name="action_show_hide_overlay"/>
    <addaction name="separator"/>
    <addaction name="actionZoom_in"/>
    <addaction name="actionZoom_out"/>
@@ -508,7 +508,7 @@
    </attribute>
    <addaction name="actionUndo"/>
    <addaction name="actionClear"/>
-   <addaction name="actionShow_hide_analysis_area"/>
+   <addaction name="action_show_hide_analysis_area"/>
    <addaction name="actionInvert_analysis_area"/>
   </widget>
   <action name="actionSave">
@@ -585,7 +585,7 @@
     <string>Open manual</string>
    </property>
   </action>
-  <action name="actionShow_hide_overlay">
+  <action name="action_show_hide_overlay">
    <property name="checkable">
     <bool>true</bool>
    </property>
@@ -796,7 +796,7 @@
     <string>Choose Workspace</string>
    </property>
   </action>
-  <action name="actionShow_hide_analysis_area">
+  <action name="action_show_hide_analysis_area">
    <property name="checkable">
     <bool>true</bool>
    </property>
@@ -862,7 +862,7 @@
     <string>Invert analysis area</string>
    </property>
   </action>
-  <action name="actionShow_hide_analysis_overlay">
+  <action name="action_show_hide_analysis_overlay">
    <property name="checkable">
     <bool>true</bool>
    </property>

--- a/ViAn/Test/test_video_player.cpp
+++ b/ViAn/Test/test_video_player.cpp
@@ -127,6 +127,12 @@ void test_video_player::test_toggle_overlay() {
     QVERIFY(v_player->is_showing_overlay());
     v_player->toggle_overlay();
     QVERIFY(!v_player->is_showing_overlay());
+
+    bool original_value = v_player->analysis_overlay->is_showing_overlay();
+    v_player->toggle_analysis_overlay();
+    QVERIFY(v_player->is_showing_analysis_overlay() != original_value);
+    v_player->toggle_analysis_overlay();
+    QVERIFY(v_player->is_showing_analysis_overlay() == original_value);
 }
 
 /**

--- a/ViAn/ViAn.pro
+++ b/ViAn/ViAn.pro
@@ -16,6 +16,7 @@ TEMPLATE = app
 # GENERAL
 #
 SOURCES += main.cpp \
+    Video/analysisoverlay.cpp
 
 #
 # TEST
@@ -26,6 +27,7 @@ SOURCES += Test/test_video_player.cpp\
 HEADERS += Test/test_video_player.h \
     Test/filehandlertest.h \
     Test/test_mainwindow.h \
+    Video/analysisoverlay.h
 
 #
 # LIBRARY

--- a/ViAn/ViAn.pro
+++ b/ViAn/ViAn.pro
@@ -15,8 +15,7 @@ TEMPLATE = app
 #
 # GENERAL
 #
-SOURCES += main.cpp \
-    Video/analysisoverlay.cpp
+SOURCES += main.cpp
 
 #
 # TEST
@@ -26,8 +25,7 @@ SOURCES += Test/test_video_player.cpp\
     Test/test_mainwindow.cpp
 HEADERS += Test/test_video_player.h \
     Test/filehandlertest.h \
-    Test/test_mainwindow.h \
-    Video/analysisoverlay.h
+    Test/test_mainwindow.h
 
 #
 # LIBRARY
@@ -65,6 +63,7 @@ RESOURCES += resources.qrc
 #
 SOURCES += Video/video_player.cpp \
     Video/overlay.cpp \
+    Video/analysisoverlay.cpp \
     Video/shapes/arrow.cpp \
     Video/shapes/circle.cpp \
     Video/shapes/line.cpp \
@@ -76,6 +75,7 @@ SOURCES += Video/video_player.cpp \
     Video/shapes/analysarea.cpp
 HEADERS += Video/video_player.h \
     Video/overlay.h \
+    Video/analysisoverlay.h \
     Video/shapes/arrow.h \
     Video/shapes/circle.h \
     Video/shapes/line.h \

--- a/ViAn/Video/analysisoverlay.cpp
+++ b/ViAn/Video/analysisoverlay.cpp
@@ -4,6 +4,7 @@
  * @brief AnalysisOverlay::AnalysisOverlay
  */
 AnalysisOverlay::AnalysisOverlay() {
+    // Temporary areas to show, since there's no analysis yet.
     add_area(2, cv::Point(50,50), cv::Point(150,150));
     add_area(3, cv::Point(50,50), cv::Point(150,150));
     add_area(4, cv::Point(50,50), cv::Point(150,150));

--- a/ViAn/Video/analysisoverlay.cpp
+++ b/ViAn/Video/analysisoverlay.cpp
@@ -19,8 +19,9 @@ AnalysisOverlay::AnalysisOverlay() {
 /**
  * @brief AnalysisOverlay::draw_overlay
  * Draws an overlay with the detected areas, on top of the specified frame.
- * @param img Frame to draw on
+ * @param frame Frame to draw on.
  * @param frame_nr Number of the frame currently shown in the video.
+ * @return Returns the frame with the overlay.
  */
 cv::Mat AnalysisOverlay::draw_overlay(cv::Mat &frame, int frame_nr) {
     if (showing_overlay) {

--- a/ViAn/Video/analysisoverlay.cpp
+++ b/ViAn/Video/analysisoverlay.cpp
@@ -4,6 +4,15 @@
  * @brief AnalysisOverlay::AnalysisOverlay
  */
 AnalysisOverlay::AnalysisOverlay() {
+    add_area(2, cv::Point(50,50), cv::Point(150,150));
+    add_area(3, cv::Point(50,50), cv::Point(150,150));
+    add_area(4, cv::Point(50,50), cv::Point(150,150));
+    add_area(5, cv::Point(50,50), cv::Point(150,150));
+    add_area(6, cv::Point(50,50), cv::Point(150,150));
+    add_area(7, cv::Point(50,50), cv::Point(150,150));
+    add_area(8, cv::Point(50,50), cv::Point(150,150));
+    add_area(9, cv::Point(50,50), cv::Point(150,150));
+    add_area(10, cv::Point(150,150), cv::Point(250,170));
 }
 
 /**
@@ -13,9 +22,37 @@ AnalysisOverlay::AnalysisOverlay() {
  * @param frame_nr Number of the frame currently shown in the video.
  */
 cv::Mat AnalysisOverlay::draw_overlay(cv::Mat &frame, int frame_nr) {
-    cv::Point draw_start(50, 50);
-    cv::Point draw_end(150, 150);
-    cv::Rect rect(draw_start, draw_end);
-    cv::rectangle(frame, rect, cv::Scalar(255, 0, 0), 5);
+    if (showing_overlay) {
+        for (std::pair<cv::Point, cv::Point> area : detections[frame_nr]) {
+            cv::Rect rect(area.first, area.second);
+            cv::rectangle(frame, rect, cv::Scalar(255, 0, 0), 5);
+        }
+    }
     return frame;
+}
+
+/**
+ * @brief AnalysisOverlay::add_area
+ * @param frame_nr Frame associated with the area.
+ * @param start Start point.
+ * @param end End point.
+ */
+void AnalysisOverlay::add_area(int frame_nr, cv::Point start, cv::Point end) {
+    std::pair <cv::Point, cv::Point> pair(start, end);
+    detections[frame_nr].push_back(pair);
+}
+
+/**
+ * @brief AnalysisOverlay::is_showing_overlay
+ * @return Returns true if the analysis overlay is showing, else false.
+ */
+bool AnalysisOverlay::is_showing_overlay() {
+    return showing_overlay;
+}
+
+/**
+ * @brief AnalysisOverlay::toggle_showing
+ */
+void AnalysisOverlay::toggle_showing() {
+    showing_overlay = !showing_overlay;
 }

--- a/ViAn/Video/analysisoverlay.cpp
+++ b/ViAn/Video/analysisoverlay.cpp
@@ -1,0 +1,21 @@
+#include "analysisoverlay.h"
+
+/**
+ * @brief AnalysisOverlay::AnalysisOverlay
+ */
+AnalysisOverlay::AnalysisOverlay() {
+}
+
+/**
+ * @brief AnalysisOverlay::draw_overlay
+ * Draws an overlay with the detected areas, on top of the specified frame.
+ * @param img Frame to draw on
+ * @param frame_nr Number of the frame currently shown in the video.
+ */
+cv::Mat AnalysisOverlay::draw_overlay(cv::Mat &frame, int frame_nr) {
+    cv::Point draw_start(50, 50);
+    cv::Point draw_end(150, 150);
+    cv::Rect rect(draw_start, draw_end);
+    cv::rectangle(frame, rect, cv::Scalar(255, 0, 0), 5);
+    return frame;
+}

--- a/ViAn/Video/analysisoverlay.h
+++ b/ViAn/Video/analysisoverlay.h
@@ -7,8 +7,14 @@ class AnalysisOverlay {
 public:
     AnalysisOverlay();
     cv::Mat draw_overlay(cv::Mat &frame, int frame_nr);
+    void add_area(int frame_nr, cv::Point start, cv::Point end);
+    bool is_showing_overlay();
+    void toggle_showing();
 private:
-    //std::map<int, std::vector<XX>> detections;
+    // Map of vectors with start and end coordinates (as a pair of points)
+    std::map<int, std::vector< std::pair<cv::Point, cv::Point> > > detections;
+
+    bool showing_overlay = true;
 };
 
 #endif // ANALYSISOVERLAY_H

--- a/ViAn/Video/analysisoverlay.h
+++ b/ViAn/Video/analysisoverlay.h
@@ -1,0 +1,14 @@
+#ifndef ANALYSISOVERLAY_H
+#define ANALYSISOVERLAY_H
+
+#include "opencv2/opencv.hpp"
+
+class AnalysisOverlay {
+public:
+    AnalysisOverlay();
+    cv::Mat draw_overlay(cv::Mat &frame, int frame_nr);
+private:
+    //std::map<int, std::vector<XX>> detections;
+};
+
+#endif // ANALYSISOVERLAY_H

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -153,6 +153,7 @@ void video_player::convert_frame(bool scale) {
 cv::Mat video_player::process_frame(cv::Mat &src, bool scale) {
     // Copy the frame, so that we don't alter the original frame (which will be reused next draw loop).
     cv::Mat processed_frame = src.clone();
+    processed_frame = analysis_overlay->draw_overlay(processed_frame, get_current_frame_num());
     processed_frame = video_overlay->draw_overlay(processed_frame, get_current_frame_num());
     if (choosing_zoom_area) {
         processed_frame = zoom_area->draw(processed_frame);

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -271,6 +271,14 @@ bool video_player::is_showing_overlay() {
 }
 
 /**
+ * @brief video_player::is_showing_analysis_overlay
+ * @return Returns true if the analysis overlay is showing, else false.
+ */
+bool video_player::is_showing_analysis_overlay() {
+    return analysis_overlay->is_showing_overlay();
+}
+
+/**
  * @brief video_player::is_showing_analysis_tool
  * @return Returns true if the analysis area tool is showing, else false.
  */
@@ -538,6 +546,16 @@ void video_player::inc_playback_speed() {
  */
 void video_player::toggle_overlay() {
     video_overlay->toggle_overlay();
+    update_overlay();
+}
+
+/**
+ * @brief video_player::toggle_analysis_overlay
+ * Toggles the showing of the analysis overlay, and if video is paused updates
+ * the frame in the GUI to show with/without the overlay.
+ */
+void video_player::toggle_analysis_overlay() {
+    analysis_overlay->toggle_showing();
     update_overlay();
 }
 

--- a/ViAn/Video/video_player.h
+++ b/ViAn/Video/video_player.h
@@ -13,6 +13,7 @@
 #include <QImageWriter>
 #include <QWaitCondition>
 #include "overlay.h"
+#include "analysisoverlay.h"
 
 #include <chrono>
 
@@ -159,6 +160,7 @@ private:
     int beta = 0;
 
     Overlay* video_overlay = new Overlay();
+    AnalysisOverlay* analysis_overlay = new AnalysisOverlay();
 };
 
 #endif // VIDEO_PLAYER_H

--- a/ViAn/Video/video_player.h
+++ b/ViAn/Video/video_player.h
@@ -28,6 +28,7 @@ public:
     bool is_paused();
     bool is_stopped();
     bool is_showing_overlay();
+    bool is_showing_analysis_overlay();
     bool is_showing_analysis_tool();
     std::string export_current_frame(std::string path_to_folder, std::string file_name);
     bool video_open();
@@ -50,6 +51,7 @@ public:
     double get_contrast();
     int get_brightness();
     void toggle_overlay();
+    void toggle_analysis_overlay();
     void set_overlay_tool(SHAPES shape);
     void set_overlay_colour(QColor colour);
     void undo_overlay();


### PR DESCRIPTION
An overlay for the analysis is now created. It can be turned on and off from the menu and toolbar.
Since there're no analysis yet, it only shows some squares during the first 1 frames for now.
Areas can be added to the overlay by using `add_area` with a frame number and coordinates for two corners of the area.