### PR TITLE
Added FPS dialog class

### DIFF
--- a/ViAn/GUI/fpsdialog.cpp
+++ b/ViAn/GUI/fpsdialog.cpp
@@ -1,0 +1,38 @@
+#include "fpsdialog.h"
+
+/**
+ * @brief FPSDialog::FPSDialog
+ */
+FPSDialog::FPSDialog() {
+}
+
+/**
+ * @brief FPSDialog::get_fps
+ * Requests the user to enter FPS in a dialog window.
+ * @param parent The parent window.
+ * @return Returns the FPS, or -1 if cancelled.
+ */
+float FPSDialog::get_fps(QWidget* parent) {
+    float fps = FPS_DEFAULT;
+
+    // Create the text shown in the dialog
+    QString fps_text = QString("FPS [");
+    fps_text.append(QString::number(FPS_MIN));
+    fps_text.append(" - ");
+    fps_text.append(QString::number(FPS_MAX));
+    fps_text.append("]: ");
+
+    // Create the dialog
+    CustomDialog dialog("FPS", parent);
+    dialog.addLabel("Enter value:");
+    dialog.addDblSpinBoxF(fps_text, FPS_MIN, FPS_MAX, &fps, FPS_DECIMALS, FPS_STEP,
+                          "Choose FPS value with the input box.");
+
+    // Show the dialog (execution will stop here until the dialog is finished)
+    dialog.exec();
+
+    if (dialog.wasCancelled()) {
+        return -1;
+    }
+    return fps;
+}

--- a/ViAn/GUI/fpsdialog.h
+++ b/ViAn/GUI/fpsdialog.h
@@ -1,0 +1,17 @@
+#ifndef FPSDIALOG_H
+#define FPSDIALOG_H
+
+#include "Library/customdialog.h"
+
+class FPSDialog {
+public:
+    FPSDialog();
+    float get_fps(QWidget* parent);
+private:
+    // Constants for the FPS dialog. Defines the limits, number
+    // of decimals, default value, and step for the input box.
+    float FPS_MIN = 1, FPS_MAX = 25, FPS_STEP = 0.1, FPS_DEFAULT = 1;
+    int FPS_DECIMALS = 1;
+};
+
+#endif // FPSDIALOG_H

--- a/ViAn/ViAn.pro
+++ b/ViAn/ViAn.pro
@@ -40,8 +40,9 @@ SOURCES += GUI/mainwindow.cpp \
     GUI/icononbuttonhandler.cpp \
     GUI/qtreeitems.cpp \
     GUI/bookmarkview.cpp \
+    GUI/bookmarkitem.cpp \
     GUI/makeproject.cpp \
-    GUI/bookmarkitem.cpp
+    GUI/fpsdialog.cpp
 
 
 HEADERS  += GUI/mainwindow.h \
@@ -49,8 +50,9 @@ HEADERS  += GUI/mainwindow.h \
     GUI/action.h \
     GUI/qtreeitems.h \
     GUI/bookmarkview.h \
-    GUI/makeproject.h
-    GUI/bookmarkitem.h
+    GUI/bookmarkitem.h \
+    GUI/makeproject.h \
+    GUI/fpsdialog.h
 
 FORMS    += GUI/mainwindow.ui \
     GUI/makeproject.ui


### PR DESCRIPTION
To get the FPS, create an instance of the `FPSDialog` class and call `get_fps()` with the parent window.
There're some constants in the FPS dialog class that can be adjusted at will (I just picked something looking reasonable).