### PR TITLE
Read&Write overlay

### DIFF
--- a/ViAn/Test/test_video_player.cpp
+++ b/ViAn/Test/test_video_player.cpp
@@ -140,7 +140,7 @@ void test_video_player::test_toggle_overlay() {
  */
 void test_video_player::test_set_overlay_tool() {
     mvideo->set_overlay_tool(RECTANGLE);
-    QVERIFY(mvideo->video_overlay->get_shape() == RECTANGLE);
+    QVERIFY(mvideo->video_overlay->get_tool() == RECTANGLE);
 }
 
 /**

--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -86,7 +86,7 @@ void Overlay::set_tool(SHAPES s) {
  * @param col New colour to be set.
  */
 void Overlay::set_colour(QColor col) {
-    current_colour = col;
+    current_nt_colour = col;
 }
 
 /**

--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -233,10 +233,14 @@ void Overlay::clear(int frame_nr) {
 void Overlay::read(const QJsonObject& json) {
     QJsonArray json_overlays = json["overlays"].toArray();
     for(int i = 0; i != json_overlays.size(); i++) {
+        // For each overlay, get the associated frame number
+        // and all drawings.
         QJsonObject json_overlay = json_overlays[i].toObject();
         int frame_nr = json_overlay["frame"].toInt();
         QJsonArray json_drawings = json_overlay["drawings"].toArray();
         for(int i = 0; i != json_drawings.size(); i++) {
+            // For each drawing, get the shape type and read
+            // a shape of that type.
             QJsonObject json_shape = json_drawings[i].toObject();
             int shape_i = json_shape["shape"].toInt();
             SHAPES shape_t = static_cast<SHAPES>(shape_i);
@@ -257,12 +261,12 @@ void Overlay::write(QJsonObject& json) {
     for (auto const& map_entry : overlays) {
         QJsonObject json_overlay;
         QJsonArray json_drawings;
-        foreach (Shape* s, map_entry.second) {
+        foreach (Shape* s, map_entry.second) { // Second member is the value, i.e. the drawings.
             QJsonObject json_shape;
             s->write(json_shape);
             json_drawings.append(json_shape);
         }
-        json_overlay["frame"] = map_entry.first;
+        json_overlay["frame"] = map_entry.first; // First member is the key, i.e. the frame number.
         json_overlay["drawings"] = json_drawings;
         json_overlays.append(json_overlay);
     }

--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -56,7 +56,7 @@ void Overlay::set_showing_overlay(bool value) {
 void Overlay::set_tool(SHAPES s) {
     current_shape = s;
 
-    // If the text option is choosen, a string and size will be entered by the user.
+    // If the text option is chosen, a string and size will be entered by the user.
     if (s == TEXT) {
         std::string input_string = current_string.toStdString();
         float input_font_scale = current_font_scale;
@@ -89,15 +89,15 @@ void Overlay::set_colour(QColor col) {
 
 /**
  * @brief Overlay::get_colour
- * @return The currenty choosen colour.
+ * @return The currenty chosen colour.
  */
 QColor Overlay::get_colour() {
     return current_colour;
 }
 
 /**
- * @brief Overlay::get_shape
- * @return The currently choosen shape
+ * @brief Overlay::get_tool
+ * @return The currently chosen tool
  */
 SHAPES Overlay::get_tool() {
     return current_shape;
@@ -136,7 +136,7 @@ Shape* Overlay::get_empty_shape(SHAPES shape_type) {
 
 /**
  * @brief Overlay::mouse_pressed
- * Creates a drawing shape with the prechoosen colour
+ * Creates a drawing shape with the prechosen colour
  * and shape, if the overlay is visible.
  * @param pos Mouse coordinates on the frame.
  * @param frame_nr Number of the frame currently shown in the video.

--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -104,11 +104,11 @@ SHAPES Overlay::get_tool() {
 }
 
 /**
- * @brief get_empty_shape
+ * @brief Overlay::get_empty_shape
  * @param shape_type
  * @return Returns a new shape of the given type.
  */
-Shape* get_empty_shape(SHAPES shape_type) {
+Shape* Overlay::get_empty_shape(SHAPES shape_type) {
     switch (shape_type) {
         case RECTANGLE:
             return new Rectangle();

--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -99,8 +99,39 @@ QColor Overlay::get_colour() {
  * @brief Overlay::get_shape
  * @return The currently choosen shape
  */
-SHAPES Overlay::get_shape() {
+SHAPES Overlay::get_tool() {
     return current_shape;
+}
+
+/**
+ * @brief get_empty_shape
+ * @param shape_type
+ * @return Returns a new shape of the given type.
+ */
+Shape* get_empty_shape(SHAPES shape_type) {
+    switch (shape_type) {
+        case RECTANGLE:
+            return new Rectangle();
+            break;
+        case CIRCLE:
+            return new Circle();
+            break;
+        case LINE:
+            return new Line();
+            break;
+        case ARROW:
+            return new Arrow();
+            break;
+        case PEN:
+            return new Pen();
+            break;
+        case TEXT:
+            return new Text();
+            break;
+        default:
+            return nullptr;
+            break;
+    }
 }
 
 /**
@@ -209,29 +240,7 @@ void Overlay::read(const QJsonObject& json) {
             QJsonObject json_shape = json_drawings[i].toObject();
             int shape_i = json_shape["shape"].toInt();
             SHAPES shape_t = static_cast<SHAPES>(shape_i);
-            Shape* shape;
-            switch (shape_t) {
-                case RECTANGLE:
-                    shape = new Rectangle();
-                    break;
-                case CIRCLE:
-                    shape = new Circle();
-                    break;
-                case LINE:
-                    shape = new Line();
-                    break;
-                case ARROW:
-                    shape = new Arrow();
-                    break;
-                case PEN:
-                    shape = new Pen();
-                    break;
-                case TEXT:
-                    shape = new Text();
-                    break;
-                default:
-                    break;
-            }
+            Shape* shape = get_empty_shape(shape_t);
             shape->read(json_shape);
             overlays[frame_nr].append(shape);
         }

--- a/ViAn/Video/overlay.cpp
+++ b/ViAn/Video/overlay.cpp
@@ -195,3 +195,28 @@ void Overlay::clear(int frame_nr) {
         overlays[frame_nr].clear();
     }
 }
+
+/**
+ * @brief Overlay::read
+ * @param json
+ * Reads the overlay from a Json object.
+ */
+void Overlay::read(const QJsonObject& json){
+    this->draw_end.y = json["p2y"].toInt();
+}
+
+/**
+ * @brief Overlay::write
+ * @param json
+ * Writes the overlay to a Json object.
+ */
+void Overlay::write(QJsonObject& json){
+    QJsonArray json_drawings;
+    foreach (Shape* s, overlays[frame_nr]) {
+        QJsonObject json_shape;
+        s->write(json_shape);
+        json_drawings.append(json_shape);
+    }
+    json["bookmarks"] = json_drawings;
+}
+

--- a/ViAn/Video/overlay.h
+++ b/ViAn/Video/overlay.h
@@ -31,7 +31,7 @@ public:
     void set_tool(SHAPES s);
     void set_colour(QColor col);
     QColor get_colour();
-    SHAPES get_shape();
+    SHAPES get_tool();
     void mouse_pressed(QPoint pos, int frame_nr);
     void mouse_released(QPoint pos, int frame_nr);
     void mouse_moved(QPoint pos, int frame_nr);
@@ -43,6 +43,7 @@ public:
 
 private:
     void update_drawing_position(QPoint pos, int frame_nr);
+    Shape* get_empty_shape(SHAPES shape_type);
 
     bool show_overlay = false;
 

--- a/ViAn/Video/overlay.h
+++ b/ViAn/Video/overlay.h
@@ -1,8 +1,13 @@
 #ifndef OVERLAY_H
 #define OVERLAY_H
 
+#include <iostream>
 #include <QImage>
 #include <QColor>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QInputDialog>
 #include "shapes/shape.h"
 #include "shapes/rectangle.h"
 #include "shapes/circle.h"

--- a/ViAn/Video/overlay.h
+++ b/ViAn/Video/overlay.h
@@ -33,6 +33,9 @@ public:
     void undo(int frame_nr);
     void clear(int frame_nr);
 
+    void read(const QJsonObject& json);
+    void write(QJsonObject& json);
+
 private:
     void update_drawing_position(QPoint pos, int frame_nr);
 

--- a/ViAn/Video/shapes/arrow.cpp
+++ b/ViAn/Video/shapes/arrow.cpp
@@ -2,6 +2,12 @@
 
 /**
  * @brief Arrow::Arrow
+ */
+Arrow::Arrow() : Shape(SHAPES::ARROW) {
+}
+
+/**
+ * @brief Arrow::Arrow
  * @param col Colour of the new object
  * @param pos Starting point for the new object
  */
@@ -35,4 +41,13 @@ void Arrow::handle_new_pos(QPoint pos) {
  */
 void Arrow::write(QJsonObject& json) {
     write_shape(json);
+}
+
+/**
+ * @brief Arrow::read
+ * @param json
+ * Reads from a Json object.
+ */
+void Arrow::read(const QJsonObject& json) {
+    read_shape(json);
 }

--- a/ViAn/Video/shapes/arrow.cpp
+++ b/ViAn/Video/shapes/arrow.cpp
@@ -5,7 +5,7 @@
  * @param col Colour of the new object
  * @param pos Starting point for the new object
  */
-Arrow::Arrow(QColor col, QPoint pos) : Shape(col, pos) {
+Arrow::Arrow(QColor col, QPoint pos) : Shape(SHAPES::ARROW, col, pos) {
 }
 
 /**
@@ -29,16 +29,10 @@ void Arrow::handle_new_pos(QPoint pos) {
 }
 
 /**
- * @brief Arrow::read_shape
- * Stores specific information associated
+ * @brief Arrow::write
  * @param json
+ * Writes to a Json object.
  */
-void Arrow::read_shape(const QJsonObject &json) {
-}
-
-/**
- * @brief Arrow::write_shape
- * @param json
- */
-void Arrow::write_shape(QJsonObject &json) {
+void Arrow::write(QJsonObject& json) {
+    write_shape(json);
 }

--- a/ViAn/Video/shapes/arrow.cpp
+++ b/ViAn/Video/shapes/arrow.cpp
@@ -27,3 +27,18 @@ cv::Mat Arrow::draw(cv::Mat &frame) {
  */
 void Arrow::handle_new_pos(QPoint pos) {
 }
+
+/**
+ * @brief Arrow::read_shape
+ * Stores specific information associated
+ * @param json
+ */
+void Arrow::read_shape(const QJsonObject &json) {
+}
+
+/**
+ * @brief Arrow::write_shape
+ * @param json
+ */
+void Arrow::write_shape(QJsonObject &json) {
+}

--- a/ViAn/Video/shapes/arrow.h
+++ b/ViAn/Video/shapes/arrow.h
@@ -5,10 +5,12 @@
 
 class Arrow : public Shape {
 public:
+    Arrow();
     Arrow(QColor col, QPoint pos);
     cv::Mat draw(cv::Mat &frame) override;
     void handle_new_pos(QPoint pos) override;
     void write(QJsonObject& json) override;
+    void read(const QJsonObject& json) override;
 };
 
 #endif // ARROW_H

--- a/ViAn/Video/shapes/arrow.h
+++ b/ViAn/Video/shapes/arrow.h
@@ -8,6 +8,7 @@ public:
     Arrow(QColor col, QPoint pos);
     cv::Mat draw(cv::Mat &frame) override;
     void handle_new_pos(QPoint pos) override;
+    void write(QJsonObject& json) override;
 };
 
 #endif // ARROW_H

--- a/ViAn/Video/shapes/circle.cpp
+++ b/ViAn/Video/shapes/circle.cpp
@@ -5,7 +5,7 @@
  * @param col Colour of the new object
  * @param pos Starting point for the new object
  */
-Circle::Circle(QColor col, QPoint pos) : Shape(col, pos) {
+Circle::Circle(QColor col, QPoint pos) : Shape(SHAPES::CIRCLE, col, pos) {
 }
 
 /**
@@ -30,4 +30,13 @@ cv::Mat Circle::draw(cv::Mat &frame) {
  * @param pos
  */
 void Circle::handle_new_pos(QPoint pos) {
+}
+
+/**
+ * @brief Circle::write
+ * @param json
+ * Writes to a Json object.
+ */
+void Circle::write(QJsonObject& json) {
+    write_shape(json);
 }

--- a/ViAn/Video/shapes/circle.cpp
+++ b/ViAn/Video/shapes/circle.cpp
@@ -1,5 +1,8 @@
 #include "circle.h"
 
+Circle::Circle() : Shape(SHAPES::CIRCLE) {
+}
+
 /**
  * @brief Circle::Circle
  * @param col Colour of the new object
@@ -39,4 +42,13 @@ void Circle::handle_new_pos(QPoint pos) {
  */
 void Circle::write(QJsonObject& json) {
     write_shape(json);
+}
+
+/**
+ * @brief Circle::read
+ * @param json
+ * Reads from a Json object.
+ */
+void Circle::read(const QJsonObject& json) {
+    read_shape(json);
 }

--- a/ViAn/Video/shapes/circle.h
+++ b/ViAn/Video/shapes/circle.h
@@ -8,6 +8,7 @@ public:
     Circle(QColor col, QPoint pos);
     cv::Mat draw(cv::Mat &frame) override;
     void handle_new_pos(QPoint pos) override;
+    void write(QJsonObject& json) override;
 };
 
 #endif // CIRCLE_H

--- a/ViAn/Video/shapes/circle.h
+++ b/ViAn/Video/shapes/circle.h
@@ -5,10 +5,12 @@
 
 class Circle : public Shape {
 public:
+    Circle();
     Circle(QColor col, QPoint pos);
     cv::Mat draw(cv::Mat &frame) override;
     void handle_new_pos(QPoint pos) override;
     void write(QJsonObject& json) override;
+    void read(const QJsonObject& json) override;
 };
 
 #endif // CIRCLE_H

--- a/ViAn/Video/shapes/line.cpp
+++ b/ViAn/Video/shapes/line.cpp
@@ -2,6 +2,12 @@
 
 /**
  * @brief Line::Line
+ */
+Line::Line() : Shape(SHAPES::LINE) {
+}
+
+/**
+ * @brief Line::Line
  * @param col Colour of the new object
  * @param pos Starting point for the new object
  */
@@ -35,4 +41,13 @@ void Line::handle_new_pos(QPoint pos) {
  */
 void Line::write(QJsonObject& json) {
     write_shape(json);
+}
+
+/**
+ * @brief Line::read
+ * @param json
+ * Reads from a Json object.
+ */
+void Line::read(const QJsonObject& json) {
+    read_shape(json);
 }

--- a/ViAn/Video/shapes/line.cpp
+++ b/ViAn/Video/shapes/line.cpp
@@ -5,7 +5,7 @@
  * @param col Colour of the new object
  * @param pos Starting point for the new object
  */
-Line::Line(QColor col, QPoint pos) : Shape(col, pos) {
+Line::Line(QColor col, QPoint pos) : Shape(SHAPES::LINE, col, pos) {
 }
 
 /**
@@ -26,4 +26,13 @@ cv::Mat Line::draw(cv::Mat &frame) {
  * @param pos
  */
 void Line::handle_new_pos(QPoint pos) {
+}
+
+/**
+ * @brief Line::write
+ * @param json
+ * Writes to a Json object.
+ */
+void Line::write(QJsonObject& json) {
+    write_shape(json);
 }

--- a/ViAn/Video/shapes/line.h
+++ b/ViAn/Video/shapes/line.h
@@ -8,6 +8,7 @@ public:
     Line(QColor col, QPoint pos);
     cv::Mat draw(cv::Mat &frame) override;
     void handle_new_pos(QPoint pos) override;
+    void write(QJsonObject& json) override;
 };
 
 #endif // LINE_H

--- a/ViAn/Video/shapes/line.h
+++ b/ViAn/Video/shapes/line.h
@@ -5,10 +5,12 @@
 
 class Line : public Shape {
 public:
+    Line();
     Line(QColor col, QPoint pos);
     cv::Mat draw(cv::Mat &frame) override;
     void handle_new_pos(QPoint pos) override;
     void write(QJsonObject& json) override;
+    void read(const QJsonObject& json) override;
 };
 
 #endif // LINE_H

--- a/ViAn/Video/shapes/pen.cpp
+++ b/ViAn/Video/shapes/pen.cpp
@@ -5,7 +5,7 @@
  * @param col Colour of the new object
  * @param pos Starting point for the new object
  */
-Pen::Pen(QColor col, QPoint pos) : Shape(col, pos) {
+Pen::Pen(QColor col, QPoint pos) : Shape(SHAPES::PEN, col, pos) {
 }
 
 /**
@@ -30,4 +30,23 @@ cv::Mat Pen::draw(cv::Mat &frame) {
 void Pen::handle_new_pos(QPoint pos) {
     std::pair<cv::Point, cv::Point> line(draw_end, qpoint_to_point(pos));
     lines.push_back(line);
+}
+
+/**
+ * @brief Pen::write
+ * @param json
+ * Writes to a Json object.
+ */
+void Pen::write(QJsonObject& json) {
+    write_shape(json);
+    QJsonArray json_lines;
+    for (std::pair<cv::Point, cv::Point> line : lines) {
+        QJsonObject json_line;
+        json["p1x"] = line.first.x;
+        json["p1y"] = line.first.y;
+        json["p2x"] = line.second.x;
+        json["p2y"] = line.second.y;
+        json_lines.append(json_line);
+    }
+    json["lines"] = json_lines;
 }

--- a/ViAn/Video/shapes/pen.cpp
+++ b/ViAn/Video/shapes/pen.cpp
@@ -2,6 +2,12 @@
 
 /**
  * @brief Pen::Pen
+ */
+Pen::Pen() : Shape(SHAPES::PEN) {
+}
+
+/**
+ * @brief Pen::Pen
  * @param col Colour of the new object
  * @param pos Starting point for the new object
  */
@@ -42,11 +48,32 @@ void Pen::write(QJsonObject& json) {
     QJsonArray json_lines;
     for (std::pair<cv::Point, cv::Point> line : lines) {
         QJsonObject json_line;
-        json["p1x"] = line.first.x;
-        json["p1y"] = line.first.y;
-        json["p2x"] = line.second.x;
-        json["p2y"] = line.second.y;
+        json_line["p1x"] = line.first.x;
+        json_line["p1y"] = line.first.y;
+        json_line["p2x"] = line.second.x;
+        json_line["p2y"] = line.second.y;
         json_lines.append(json_line);
     }
     json["lines"] = json_lines;
+}
+
+/**
+ * @brief Pen::read
+ * @param json
+ * Reads from a Json object.
+ */
+void Pen::read(const QJsonObject& json) {
+    read_shape(json);
+    QJsonArray json_lines = json["lines"].toArray();
+    for(int i = 0; i != json_lines.size(); i++) {
+        QJsonObject json_line = json_lines[i].toObject();
+        cv::Point start;
+        start.x = json_line["p1x"].toInt();
+        start.y = json_line["p1y"].toInt();
+        cv::Point end;
+        end.x = json_line["p2x"].toInt();
+        end.y = json_line["p2y"].toInt();
+        std::pair<cv::Point, cv::Point> line(start, end);
+        lines.push_back(line);
+    }
 }

--- a/ViAn/Video/shapes/pen.h
+++ b/ViAn/Video/shapes/pen.h
@@ -8,6 +8,7 @@ public:
     Pen(QColor col, QPoint pos);
     cv::Mat draw(cv::Mat &frame) override;
     void handle_new_pos(QPoint pos) override;
+    void write(QJsonObject& json) override;
 private:
     std::vector<std::pair<cv::Point, cv::Point>> lines;
 };

--- a/ViAn/Video/shapes/pen.h
+++ b/ViAn/Video/shapes/pen.h
@@ -5,10 +5,12 @@
 
 class Pen : public Shape {
 public:
+    Pen();
     Pen(QColor col, QPoint pos);
     cv::Mat draw(cv::Mat &frame) override;
     void handle_new_pos(QPoint pos) override;
     void write(QJsonObject& json) override;
+    void read(const QJsonObject& json) override;
 private:
     std::vector<std::pair<cv::Point, cv::Point>> lines;
 };

--- a/ViAn/Video/shapes/rectangle.cpp
+++ b/ViAn/Video/shapes/rectangle.cpp
@@ -5,7 +5,7 @@
  * @param col Colour of the new object
  * @param pos Starting point for the new object
  */
-Rectangle::Rectangle(QColor col, QPoint pos) : Shape(col, pos) {
+Rectangle::Rectangle(QColor col, QPoint pos) : Shape(SHAPES::RECTANGLE, col, pos) {
 }
 
 /**
@@ -27,4 +27,13 @@ cv::Mat Rectangle::draw(cv::Mat &frame) {
  * @param pos
  */
 void Rectangle::handle_new_pos(QPoint pos) {
+}
+
+/**
+ * @brief Rectangle::write
+ * @param json
+ * Writes to a Json object.
+ */
+void Rectangle::write(QJsonObject& json) {
+    write_shape(json);
 }

--- a/ViAn/Video/shapes/rectangle.cpp
+++ b/ViAn/Video/shapes/rectangle.cpp
@@ -2,6 +2,12 @@
 
 /**
  * @brief Rectangle::Rectangle
+ */
+Rectangle::Rectangle() : Shape(SHAPES::RECTANGLE) {
+}
+
+/**
+ * @brief Rectangle::Rectangle
  * @param col Colour of the new object
  * @param pos Starting point for the new object
  */
@@ -36,4 +42,13 @@ void Rectangle::handle_new_pos(QPoint pos) {
  */
 void Rectangle::write(QJsonObject& json) {
     write_shape(json);
+}
+
+/**
+ * @brief Rectangle::read
+ * @param json
+ * Reads from a Json object.
+ */
+void Rectangle::read(const QJsonObject& json) {
+    read_shape(json);
 }

--- a/ViAn/Video/shapes/rectangle.h
+++ b/ViAn/Video/shapes/rectangle.h
@@ -8,6 +8,7 @@ public:
     Rectangle(QColor col, QPoint pos);
     cv::Mat draw(cv::Mat &frame) override;
     void handle_new_pos(QPoint pos) override;
+    void write(QJsonObject& json) override;
 };
 
 #endif // RECTANGLE_H

--- a/ViAn/Video/shapes/rectangle.h
+++ b/ViAn/Video/shapes/rectangle.h
@@ -5,10 +5,12 @@
 
 class Rectangle : public Shape {
 public:
+    Rectangle();
     Rectangle(QColor col, QPoint pos);
     cv::Mat draw(cv::Mat &frame) override;
     void handle_new_pos(QPoint pos) override;
     void write(QJsonObject& json) override;
+    void read(const QJsonObject& json) override;
 };
 
 #endif // RECTANGLE_H

--- a/ViAn/Video/shapes/shape.cpp
+++ b/ViAn/Video/shapes/shape.cpp
@@ -52,7 +52,8 @@ cv::Point Shape::qpoint_to_point(QPoint pnt) {
  * Reads a shape from a Json object.
  */
 void Shape::read_shape(const QJsonObject& json){
-    this->shape = json["shape"].toInt();
+    int shape_i = json["shape"].toInt();
+    this->shape = static_cast<SHAPES>(shape_i);
     this->colour[0] = json["b"].toInt();
     this->colour[1] = json["g"].toInt();
     this->colour[2] = json["r"].toInt();

--- a/ViAn/Video/shapes/shape.cpp
+++ b/ViAn/Video/shapes/shape.cpp
@@ -6,7 +6,8 @@
  * @param col Colour of the new object
  * @param pos Starting point for the new object
  */
-Shape::Shape(QColor col, QPoint pos) {
+Shape::Shape(SHAPES s, QColor col, QPoint pos) {
+    shape = s;
     colour = qcolor_to_scalar(col);
     draw_start = qpoint_to_point(pos);
     draw_end = qpoint_to_point(pos);
@@ -50,7 +51,8 @@ cv::Point Shape::qpoint_to_point(QPoint pnt) {
  * @param json
  * Reads a shape from a Json object.
  */
-void Shape::read(const QJsonObject& json){
+void Shape::read_shape(const QJsonObject& json){
+    this->shape = json["shape"].toInt();
     this->colour[0] = json["b"].toInt();
     this->colour[1] = json["g"].toInt();
     this->colour[2] = json["r"].toInt();
@@ -65,7 +67,8 @@ void Shape::read(const QJsonObject& json){
  * @param json
  * Writes a shape to a Json object.
  */
-void Shape::write(QJsonObject& json){
+void Shape::write_shape(QJsonObject& json){
+    json["shape"] = this->shape;
     json["b"] = this->colour[0];
     json["g"] = this->colour[1];
     json["r"] = this->colour[2];

--- a/ViAn/Video/shapes/shape.cpp
+++ b/ViAn/Video/shapes/shape.cpp
@@ -44,3 +44,34 @@ cv::Scalar Shape::qcolor_to_scalar(QColor col) {
 cv::Point Shape::qpoint_to_point(QPoint pnt) {
     return cv::Point(pnt.x(), pnt.y());
 }
+
+/**
+ * @brief Shape::read
+ * @param json
+ * Reads a shape from a Json object.
+ */
+void Shape::read(const QJsonObject& json){
+    this->colour[0] = json["b"].toInt();
+    this->colour[1] = json["g"].toInt();
+    this->colour[2] = json["r"].toInt();
+    this->draw_start.x = json["p1x"].toInt();
+    this->draw_start.y = json["p1y"].toInt();
+    this->draw_end.x = json["p2x"].toInt();
+    this->draw_end.y = json["p2y"].toInt();
+}
+
+/**
+ * @brief Shape::write
+ * @param json
+ * Writes a shape to a Json object.
+ */
+void Shape::write(QJsonObject& json){
+    json["b"] = this->colour[0];
+    json["g"] = this->colour[1];
+    json["r"] = this->colour[2];
+    json["p1x"] = this->draw_start.x;
+    json["p1y"] = this->draw_start.y;
+    json["p2x"] = this->draw_end.x;
+    json["p2y"] = this->draw_end.y;
+}
+

--- a/ViAn/Video/shapes/shape.cpp
+++ b/ViAn/Video/shapes/shape.cpp
@@ -3,6 +3,17 @@
 
 /**
  * @brief Shape::Shape
+ * @param s
+ */
+Shape::Shape(SHAPES s) {
+    shape = s;
+    colour = cv::Scalar();
+    draw_start = cv::Point();
+    draw_end = cv::Point();
+}
+
+/**
+ * @brief Shape::Shape
  * @param col Colour of the new object
  * @param pos Starting point for the new object
  */
@@ -47,7 +58,7 @@ cv::Point Shape::qpoint_to_point(QPoint pnt) {
 }
 
 /**
- * @brief Shape::read
+ * @brief Shape::read_shape
  * @param json
  * Reads a shape from a Json object.
  */
@@ -64,7 +75,7 @@ void Shape::read_shape(const QJsonObject& json){
 }
 
 /**
- * @brief Shape::write
+ * @brief Shape::write_shape
  * @param json
  * Writes a shape to a Json object.
  */

--- a/ViAn/Video/shapes/shape.h
+++ b/ViAn/Video/shapes/shape.h
@@ -2,6 +2,8 @@
 #define SHAPES_H
 
 #include <QImage>
+#include <QJsonObject>
+#include <QJsonArray>
 #include <qpainter.h>
 #include <algorithm>
 
@@ -12,6 +14,7 @@ enum SHAPES {RECTANGLE, CIRCLE, LINE, ARROW, PEN, TEXT};
 class Shape {
 
 public:
+    Shape(SHAPES s);
     Shape(SHAPES s, QColor col, QPoint pos);
     void update_drawing_pos(QPoint pos);
     virtual void handle_new_pos(QPoint pos) = 0;

--- a/ViAn/Video/shapes/shape.h
+++ b/ViAn/Video/shapes/shape.h
@@ -19,7 +19,9 @@ public:
     virtual cv::Mat draw(cv::Mat &frame) = 0;
 
     void read(const QJsonObject& json);
+    virtual void read_shape(const QJsonObject& json) = 0;
     void write(QJsonObject& json);
+    virtual void write_shape(QJsonObject& json) = 0;
 
     static cv::Scalar qcolor_to_scalar(QColor col);
     static cv::Point qpoint_to_point(QPoint pnt);

--- a/ViAn/Video/shapes/shape.h
+++ b/ViAn/Video/shapes/shape.h
@@ -4,18 +4,22 @@
 #include <QImage>
 #include <qpainter.h>
 #include <algorithm>
+#include <Filehandler/saveable.h>
 
 #include "opencv2/opencv.hpp"
 
 enum SHAPES {RECTANGLE, CIRCLE, LINE, ARROW, PEN, TEXT};
 
-class Shape {
+class Shape : Saveable {
 
 public:
     Shape(QColor col, QPoint pos);
     void update_drawing_pos(QPoint pos);
     virtual void handle_new_pos(QPoint pos) = 0;
     virtual cv::Mat draw(cv::Mat &frame) = 0;
+
+    void read(const QJsonObject& json);
+    void write(QJsonObject& json);
 
     static cv::Scalar qcolor_to_scalar(QColor col);
     static cv::Point qpoint_to_point(QPoint pnt);

--- a/ViAn/Video/shapes/shape.h
+++ b/ViAn/Video/shapes/shape.h
@@ -4,24 +4,21 @@
 #include <QImage>
 #include <qpainter.h>
 #include <algorithm>
-#include <Filehandler/saveable.h>
 
 #include "opencv2/opencv.hpp"
 
 enum SHAPES {RECTANGLE, CIRCLE, LINE, ARROW, PEN, TEXT};
 
-class Shape : Saveable {
+class Shape {
 
 public:
-    Shape(QColor col, QPoint pos);
+    Shape(SHAPES s, QColor col, QPoint pos);
     void update_drawing_pos(QPoint pos);
     virtual void handle_new_pos(QPoint pos) = 0;
     virtual cv::Mat draw(cv::Mat &frame) = 0;
 
     void read(const QJsonObject& json);
-    virtual void read_shape(const QJsonObject& json) = 0;
-    void write(QJsonObject& json);
-    virtual void write_shape(QJsonObject& json) = 0;
+    virtual void write(QJsonObject& json) = 0;
 
     static cv::Scalar qcolor_to_scalar(QColor col);
     static cv::Point qpoint_to_point(QPoint pnt);
@@ -30,9 +27,12 @@ public:
     static constexpr double ALPHA = 0.6; // Costant used for the opacity.
 
 protected:
+    SHAPES shape;
     cv::Scalar colour;
     cv::Point draw_start;
     cv::Point draw_end;
+
+    void write_shape(QJsonObject& json);
 };
 
 #endif // SHAPES_H

--- a/ViAn/Video/shapes/shape.h
+++ b/ViAn/Video/shapes/shape.h
@@ -17,7 +17,7 @@ public:
     virtual void handle_new_pos(QPoint pos) = 0;
     virtual cv::Mat draw(cv::Mat &frame) = 0;
 
-    void read(const QJsonObject& json);
+    virtual void read(const QJsonObject& json) = 0;
     virtual void write(QJsonObject& json) = 0;
 
     static cv::Scalar qcolor_to_scalar(QColor col);
@@ -33,6 +33,7 @@ protected:
     cv::Point draw_end;
 
     void write_shape(QJsonObject& json);
+    void read_shape(const QJsonObject& json);
 };
 
 #endif // SHAPES_H

--- a/ViAn/Video/shapes/text.cpp
+++ b/ViAn/Video/shapes/text.cpp
@@ -2,6 +2,14 @@
 
 /**
  * @brief Text::Text
+ */
+Text::Text() : Shape(SHAPES::TEXT) {
+    string = QString();
+    font_scale = 0;
+}
+
+/**
+ * @brief Text::Text
  * @param col Colour of the new object
  * @param pos Starting point for the new object
  * @param strng String to be displayed
@@ -40,4 +48,17 @@ void Text::handle_new_pos(QPoint pos) {
  */
 void Text::write(QJsonObject& json) {
     write_shape(json);
+    json["text"] = string;
+    json["font"] = font_scale;
+}
+
+/**
+ * @brief Text::read
+ * @param json
+ * Reads from a Json object.
+ */
+void Text::read(const QJsonObject& json) {
+    read_shape(json);
+    this->string = json["text"].toString();
+    this->font_scale = json["font"].toDouble();
 }

--- a/ViAn/Video/shapes/text.cpp
+++ b/ViAn/Video/shapes/text.cpp
@@ -7,7 +7,7 @@
  * @param strng String to be displayed
  * @param fnt_scl Font scale of the string
  */
-Text::Text(QColor col, QPoint pos, QString strng, double fnt_scl) : Shape(col, pos) {
+Text::Text(QColor col, QPoint pos, QString strng, double fnt_scl) : Shape(SHAPES::TEXT, col, pos) {
     string = strng;
     font_scale = fnt_scl;
 }
@@ -31,4 +31,13 @@ cv::Mat Text::draw(cv::Mat &frame) {
  * @param pos
  */
 void Text::handle_new_pos(QPoint pos) {
+}
+
+/**
+ * @brief Text::write
+ * @param json
+ * Writes to a Json object.
+ */
+void Text::write(QJsonObject& json) {
+    write_shape(json);
 }

--- a/ViAn/Video/shapes/text.h
+++ b/ViAn/Video/shapes/text.h
@@ -8,6 +8,7 @@ public:
     Text(QColor col, QPoint pos, QString strng, double fnt_scl);
     cv::Mat draw(cv::Mat &frame) override;
     void handle_new_pos(QPoint pos) override;
+    void write(QJsonObject& json) override;
 
     // Constants describing the limit and precision of the font scale value.
     static constexpr double FONT_SCALE_MIN = 0.5, FONT_SCALE_MAX = 5.0, FONT_SCALE_STEP = 0.1;

--- a/ViAn/Video/shapes/text.h
+++ b/ViAn/Video/shapes/text.h
@@ -5,10 +5,12 @@
 
 class Text : public Shape {
 public:
+    Text();
     Text(QColor col, QPoint pos, QString strng, double fnt_scl);
     cv::Mat draw(cv::Mat &frame) override;
     void handle_new_pos(QPoint pos) override;
     void write(QJsonObject& json) override;
+    void read(const QJsonObject& json) override;
 
     // Constants describing the limit and precision of the font scale value.
     static constexpr double FONT_SCALE_MIN = 0.5, FONT_SCALE_MAX = 5.0, FONT_SCALE_STEP = 0.1;


### PR DESCRIPTION
Read and write methods for the overlay (and all shapes) have been implemented. They're not used and **NOT** connected to the filehandler yet.
To do this `read()` and `write()` methods have been added to the overlay and all shapes (class `shape` have general `read_shape()` and `write_shape()` with the common parameters for all shapes). Empty constructors has also been added, and each shape now knows what type it is.
**The overlay does NOT know what video it's connected too.**
(Also fixed some misspelled comments and refactored a method-name.)