### PR TITLE
Changed representation in AnalysisOverlay

### DIFF
--- a/ViAn/Video/analysisoverlay.cpp
+++ b/ViAn/Video/analysisoverlay.cpp
@@ -4,16 +4,6 @@
  * @brief AnalysisOverlay::AnalysisOverlay
  */
 AnalysisOverlay::AnalysisOverlay() {
-    // Temporary areas to show, since there's no analysis yet.
-    add_area(2, cv::Point(50,50), cv::Point(150,150));
-    add_area(3, cv::Point(50,50), cv::Point(150,150));
-    add_area(4, cv::Point(50,50), cv::Point(150,150));
-    add_area(5, cv::Point(50,50), cv::Point(150,150));
-    add_area(6, cv::Point(50,50), cv::Point(150,150));
-    add_area(7, cv::Point(50,50), cv::Point(150,150));
-    add_area(8, cv::Point(50,50), cv::Point(150,150));
-    add_area(9, cv::Point(50,50), cv::Point(150,150));
-    add_area(10, cv::Point(150,150), cv::Point(250,170));
 }
 
 /**
@@ -25,9 +15,8 @@ AnalysisOverlay::AnalysisOverlay() {
  */
 cv::Mat AnalysisOverlay::draw_overlay(cv::Mat &frame, int frame_nr) {
     if (showing_overlay) {
-        for (std::pair<cv::Point, cv::Point> area : detections[frame_nr]) {
-            cv::Rect rect(area.first, area.second);
-            cv::rectangle(frame, rect, cv::Scalar(255, 0, 0), 5);
+        for (cv::Rect area : detections[frame_nr]) {
+            cv::rectangle(frame, area, cv::Scalar(255, 0, 0), 5);
         }
     }
     return frame;
@@ -36,12 +25,10 @@ cv::Mat AnalysisOverlay::draw_overlay(cv::Mat &frame, int frame_nr) {
 /**
  * @brief AnalysisOverlay::add_area
  * @param frame_nr Frame associated with the area.
- * @param start Start point.
- * @param end End point.
+ * @param rect The detected area.
  */
-void AnalysisOverlay::add_area(int frame_nr, cv::Point start, cv::Point end) {
-    std::pair <cv::Point, cv::Point> pair(start, end);
-    detections[frame_nr].push_back(pair);
+void AnalysisOverlay::add_area(int frame_nr, cv::Rect rect) {
+    detections[frame_nr].push_back(rect);
 }
 
 /**

--- a/ViAn/Video/analysisoverlay.cpp
+++ b/ViAn/Video/analysisoverlay.cpp
@@ -16,7 +16,7 @@ AnalysisOverlay::AnalysisOverlay() {
 cv::Mat AnalysisOverlay::draw_overlay(cv::Mat &frame, int frame_nr) {
     if (showing_overlay) {
         for (cv::Rect area : detections[frame_nr]) {
-            cv::rectangle(frame, area, cv::Scalar(255, 0, 0), 5);
+            cv::rectangle(frame, area, COLOUR, THICKNESS);
         }
     }
     return frame;

--- a/ViAn/Video/analysisoverlay.h
+++ b/ViAn/Video/analysisoverlay.h
@@ -11,6 +11,10 @@ public:
     bool is_showing_overlay();
     void toggle_showing();
 private:
+    // Colour and thickness for the graphical representation of the detected areas.
+    const cv::Scalar COLOUR = cv::Scalar(255, 0, 0);
+    const int THICKNESS = 5;
+
     // The detected areas mapped to the frame they're on.
     std::map<int, std::vector<cv::Rect>> detections;
 

--- a/ViAn/Video/analysisoverlay.h
+++ b/ViAn/Video/analysisoverlay.h
@@ -7,12 +7,12 @@ class AnalysisOverlay {
 public:
     AnalysisOverlay();
     cv::Mat draw_overlay(cv::Mat &frame, int frame_nr);
-    void add_area(int frame_nr, cv::Point start, cv::Point end);
+    void add_area(int frame_nr, cv::Rect rect);
     bool is_showing_overlay();
     void toggle_showing();
 private:
-    // Map of vectors with start and end coordinates (as a pair of points)
-    std::map<int, std::vector< std::pair<cv::Point, cv::Point> > > detections;
+    // The detected areas mapped to the frame they're on.
+    std::map<int, std::vector<cv::Rect>> detections;
 
     bool showing_overlay = true;
 };


### PR DESCRIPTION
Changed so that `AnalysisOverlay` takes a `cv::Rect` as inupt.
Also added constants for the graphical representation of the areas.