### PR TITLE
Added video name to bookmark file name.

### DIFF
--- a/ViAn/Filehandler/bookmark.cpp
+++ b/ViAn/Filehandler/bookmark.cpp
@@ -4,12 +4,14 @@
  * @brief Bookmark::Bookmark
  * @param frame_nbr Frame number associated with the bookmark.
  * @param frame Frame associated with the bookmark.
+ * @param video_file_name Name of the video associated with the bookmark.
  * @param dir_path Path to the directory to store image in.
  * @param text Text description of the bookmark.
  */
-Bookmark::Bookmark(int frame_nbr, QImage frame, QString dir_path, QString text) {
+Bookmark::Bookmark(int frame_nbr, QImage frame, QString video_file_name, QString dir_path, QString text) {
     this->frame_number = frame_nbr;
     this->frame = frame;
+    this->video_file_name = video_file_name;
     this->dir_path = dir_path;
     this->description = text;
     // There's no file path yet, since the frame has not been exported
@@ -23,6 +25,7 @@ Bookmark::Bookmark(int frame_nbr, QImage frame, QString dir_path, QString text) 
 Bookmark::Bookmark() {
     frame_number = 0;
     frame = QImage();
+    video_file_name = QString();
     dir_path = QString();
     file_path = QString();
     description = QString();
@@ -68,6 +71,7 @@ QString Bookmark::get_description() {
  */
 void Bookmark::read(const QJsonObject& json){
     this->frame_number = json["frame"].toInt();
+    this->video_file_name = json["video_name"].toString();
     this->dir_path = json["dir"].toString();
     this->file_path = json["path"].toString();
     this->description = json["note"].toString();
@@ -84,6 +88,7 @@ void Bookmark::write(QJsonObject& json){
     export_frame();
 
     json["frame"] = this->frame_number;
+    json["video_name"] = this->video_file_name;
     json["dir"] = this->dir_path;
     json["path"] = this->file_path;
     json["note"] = this->description;
@@ -109,19 +114,23 @@ void Bookmark::create_file_path() {
     // Append FRAMENR.tiff to the directory path
     QString path = QString(dir_path);
     path.append("/");
+    path.append(video_file_name);
+    path.append("_");
     path.append(QString::number(frame_number));
     path.append(".tiff");
          
-    int counter = 1;		
-    while (QFile::exists(path)) {		
-        // If file exists, try FRAMENR(X).tiff		
-        path = QString(dir_path);		
-        path.append("/");		
-        path.append(QString::number(frame_number));		
-        path.append("(");		
-        path.append(QString::number(counter));		
-        path.append(").tiff");		
-        counter++;		
+    int counter = 1;
+    while (QFile::exists(path)) {
+        // If file exists, try FRAMENR(X).tiff
+        path = QString(dir_path);
+        path.append("/");
+        path.append(video_file_name);
+        path.append("_");
+        path.append(QString::number(frame_number));
+        path.append("(");
+        path.append(QString::number(counter));
+        path.append(").tiff");
+        counter++;
     }
     // Update file path variable
     file_path = path;

--- a/ViAn/Filehandler/bookmark.h
+++ b/ViAn/Filehandler/bookmark.h
@@ -16,7 +16,7 @@
  */
 class Bookmark : Saveable{
 public:
-    Bookmark(int frame_nbr, QImage frame, QString dir_path, QString string);
+    Bookmark(int frame_nbr, QImage frame, QString video_file_name, QString dir_path, QString string);
     Bookmark();
     int get_frame_number();
     QImage get_frame();
@@ -31,6 +31,7 @@ public:
 private:
     QImage frame;           // Frame of the bookmark
     int frame_number;       // Frame at which the bookmark was taken
+    QString video_file_name;// Name of the video file.
     QString dir_path;       // Path to the directory for the bookmarks
     QString description;    // Description for the bookmark, given by user
     // Note that this variable can be altered when the bookmark is exported.

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -391,7 +391,8 @@ void MainWindow::on_bookmark_button_clicked() {
     if(!ok) return;
     int frame_number = mvideo_player->get_current_frame_num();
     QImage frame = mvideo_player->get_current_frame_unscaled();
-    Bookmark* bookmark = new Bookmark(frame_number, frame, dir.absolutePath(), bookmark_text);
+    QString video_file_name = QString::fromStdString(mvideo_player->get_file_name());
+    Bookmark* bookmark = new Bookmark(frame_number, frame, video_file_name, dir.absolutePath(), bookmark_text);
     ID id = proj->add_bookmark(playing_video->id, bookmark);
     bookmark_view->add_bookmark(playing_video->id, id, bookmark);
     playing_video->bookmarks.push_back(id);

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -53,6 +53,7 @@ bool video_player::load_video(string filename) {
     if (capture.isOpened()) {
         frame_rate = capture.get(CV_CAP_PROP_FPS);
         num_frames = capture.get(CAP_PROP_FRAME_COUNT);
+        file_path = filename;
         video_paused = false;
         zoom_area->set_size(capture.get(CAP_PROP_FRAME_WIDTH), capture.get(CAP_PROP_FRAME_HEIGHT));
         start();
@@ -309,6 +310,16 @@ int video_player::get_num_frames() {
 int video_player::get_current_frame_num() {
     // capture.get() gives the number of the frame to be read, hence the compensation of -1.
     return capture.get(CV_CAP_PROP_POS_FRAMES) - 1;
+}
+
+/**
+ * @brief video_player::get_file_name
+ * @return Returns the file name of the video that has
+ *         been loaded into the video player.
+ */
+std::string video_player::get_file_name() {
+    std::size_t found = file_path.find_last_of("/");
+    return file_path.substr(found+1);
 }
 
 /**

--- a/ViAn/Video/video_player.h
+++ b/ViAn/Video/video_player.h
@@ -38,6 +38,7 @@ public:
     void set_frame_height(int new_value);
     void set_speed_multiplier(double mult);
     double get_speed_multiplier();
+    std::string get_file_name();
 
     void inc_playback_speed();
     void dec_playback_speed();
@@ -132,6 +133,7 @@ private:
 
     double frame_rate;
     double speed_multiplier = DEFAULT_SPEED_MULT;
+    std::string file_path;
 
     bool video_stopped = false;
     bool video_paused;


### PR DESCRIPTION
Bookmarks are now exported as `VIDEOFILENAME_FRAME(X).tiff`.
(For example `seq_01.mp4_337(2).tiff`.)