### PR TITLE
Bookmark time

### DIFF
--- a/ViAn/Filehandler/bookmark.cpp
+++ b/ViAn/Filehandler/bookmark.cpp
@@ -2,14 +2,17 @@
 
 /**
  * @brief Bookmark::Bookmark
+ * @param time The time in the video associated with the bookmark (in millisecs).
  * @param frame_nbr Frame number associated with the bookmark.
  * @param frame Frame associated with the bookmark.
  * @param video_file_name Name of the video associated with the bookmark.
  * @param dir_path Path to the directory to store image in.
  * @param text Text description of the bookmark.
  */
-Bookmark::Bookmark(int frame_nbr, QImage frame, QString video_file_name, QString dir_path, QString text) {
+Bookmark::Bookmark(int time, int frame_nbr, QImage frame, QString video_file_name, QString dir_path, QString text) {
+    this->time = time;
     this->frame_number = frame_nbr;
+    std::cout << "TIME: "<<this->time<<"\n";
     this->frame = frame;
     this->video_file_name = video_file_name;
     this->dir_path = dir_path;
@@ -29,6 +32,14 @@ Bookmark::Bookmark() {
     dir_path = QString();
     file_path = QString();
     description = QString();
+}
+
+/**
+ * @brief Bookmark::get_time
+ * @return Returns the time in the video where the bookmark points to (in millisecs).
+ */
+int Bookmark::get_time() {
+    return time;
 }
 
 /**

--- a/ViAn/Filehandler/bookmark.cpp
+++ b/ViAn/Filehandler/bookmark.cpp
@@ -12,7 +12,6 @@
 Bookmark::Bookmark(int time, int frame_nbr, QImage frame, QString video_file_name, QString dir_path, QString text) {
     this->time = time;
     this->frame_number = frame_nbr;
-    std::cout << "TIME: "<<this->time<<"\n";
     this->frame = frame;
     this->video_file_name = video_file_name;
     this->dir_path = dir_path;

--- a/ViAn/Filehandler/bookmark.h
+++ b/ViAn/Filehandler/bookmark.h
@@ -16,8 +16,9 @@
  */
 class Bookmark : Saveable{
 public:
-    Bookmark(int frame_nbr, QImage frame, QString video_file_name, QString dir_path, QString string);
+    Bookmark(int time, int frame_nbr, QImage frame, QString video_file_name, QString dir_path, QString string);
     Bookmark();
+    int get_time();
     int get_frame_number();
     QImage get_frame();
     QString get_file_path();
@@ -32,6 +33,7 @@ public:
 private:
     QImage frame;           // Frame of the bookmark
     int frame_number;       // Frame at which the bookmark was taken
+    int time;               // Time of the bookmark (in millisecs)
     QString video_file_name;// Name of the video file.
     QString dir_path;       // Path to the directory for the bookmarks
     QString description;    // Description for the bookmark, given by user

--- a/ViAn/GUI/mainwindow.cpp
+++ b/ViAn/GUI/mainwindow.cpp
@@ -433,6 +433,13 @@ void MainWindow::on_action_exit_triggered() {
  * Button to add a bookmark to the bookmark view.
  */
 void MainWindow::on_bookmark_button_clicked() {
+    // Get the info from the video object.
+    // This should be done first to ensure we get the
+    // frame at the time the user clicked the button.
+    int time = mvideo_player->get_current_time();
+    int frame_number = mvideo_player->get_current_frame_num();
+    QImage frame = mvideo_player->get_current_frame_unscaled();
+    QString video_file_name = QString::fromStdString(mvideo_player->get_file_name());
     // Add bookmarks-folder to the project-folder.
     Project* proj = file_handler->get_project(((MyQTreeWidgetItem*)playing_video->parent())->id);
     QDir dir = file_handler->get_dir(proj->dir_bookmarks);
@@ -441,10 +448,7 @@ void MainWindow::on_bookmark_button_clicked() {
     bool ok;
     bookmark_text = bookmark_view->get_input_text(&ok);
     if(!ok) return;
-    int frame_number = mvideo_player->get_current_frame_num();
-    QImage frame = mvideo_player->get_current_frame_unscaled();
-    QString video_file_name = QString::fromStdString(mvideo_player->get_file_name());
-    Bookmark* bookmark = new Bookmark(frame_number, frame, video_file_name, dir.absolutePath(), bookmark_text);
+    Bookmark* bookmark = new Bookmark(time, frame_number, frame, video_file_name, dir.absolutePath(), bookmark_text);
     ID id = proj->add_bookmark(playing_video->id, bookmark);
     bookmark_view->add_bookmark(playing_video->id, id, bookmark);
     playing_video->bookmarks.push_back(id);

--- a/ViAn/Test/overlayintegrationtest.cpp
+++ b/ViAn/Test/overlayintegrationtest.cpp
@@ -54,9 +54,10 @@ void OverlayIntegrationTest::exec() {
     main->on_action_rotate_right_triggered();
 
     // Export a bookmark
+    int time = main->mvideo_player->get_current_time();
     int frame_number = main->mvideo_player->get_current_frame_num();
     QImage frame = main->mvideo_player->get_current_frame_unscaled();
-    Bookmark* bookmark = new Bookmark(frame_number, frame, "test1.mp4", "integration_test1", "Bookmark Text");
+    Bookmark* bookmark = new Bookmark(time, frame_number, frame, "test1.mp4", "integration_test1", "Bookmark Text");
     bookmark->export_frame();
 
     std::cout << "Overlay integration test finished.\n";

--- a/ViAn/Video/video_player.cpp
+++ b/ViAn/Video/video_player.cpp
@@ -333,6 +333,14 @@ int video_player::get_current_frame_num() {
 }
 
 /**
+ * @brief video_player::get_current_time
+ * @return Returns the current time in the clip in milliseconds.
+ */
+int video_player::get_current_time() {
+    return capture.get(CV_CAP_PROP_POS_MSEC);
+}
+
+/**
  * @brief video_player::get_file_name
  * @return Returns the file name of the video that has
  *         been loaded into the video player.

--- a/ViAn/Video/video_player.h
+++ b/ViAn/Video/video_player.h
@@ -40,6 +40,7 @@ public:
     double get_frame_rate();
     int get_num_frames();    
     int get_current_frame_num();
+    int get_current_time();
     void set_frame_width(int new_value);
     void set_frame_height(int new_value);
     void set_speed_multiplier(double mult);


### PR DESCRIPTION
A timestamp in **milliseconds** has now been added to the `bookmark`.

The retrieving of frame, framenumber and time when clicking the bookmark-button has also been moved so that the bookmark stores the frame at the moment the user clicks the button (previously it was stored at the moment the user had entered the text description and clicked OK).